### PR TITLE
properly resolve paths and allow collections without tests

### DIFF
--- a/CHANEGLOG.md
+++ b/CHANEGLOG.md
@@ -1,6 +1,14 @@
-## v0.0.x - (2021-xx-xx)
+## v0.0.6 - (2021-05-25)
+
+### CLI options
+
+Resolve issue with overriding paths to defauls when not provided
+Extended hardcoded list of params to disable until they are passed in as config
+
+## v0.0.5 - (2021-05-25)
 
 ### OpenApi-to-postman
+
 Bumped openapi-to-postman to the latest version, which includes extended assignPmVariables test capabilities
 Added examples for the test suite assignPmVariables function
 Added examples for the test suite overwriteRequests function
@@ -8,17 +16,20 @@ Added examples for the test suite overwriteRequests function
 ## v0.0.4 - (2021-05-18)
 
 ### OpenApi-to-postman
+
 Bumped openapi-to-postman to version 2.7.0, which includes ContentCheck test capabilities
 Added examples for the test suite generation
 Added examples for the test suite contentChecks function
 Made the "orderOfOperations" property optional
 
 ### CLI options
+
 Adds the CLI option to configure the Portman CLI in a JSON file
 Adds the CLI option to configure output location of the Postman file
-Adds the CLI option to toggle upload to Postman 
+Adds the CLI option to toggle upload to Postman
 
 ### Portman enhancements
+
 Adds the Portman option to sort Postman requests based on the "orderOfOperations" configuration
 Extends the Postman integration to upsert a collection based on the collection name
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,8 +127,9 @@ require('dotenv').config()
     (options.portmanConfigFile as string) || ('portman-config.json' as string)
   const postmanConfigFile =
     (options.postmanConfigFile as string) || ('postman-config.json' as string)
-  const testSuiteConfigFile =
-    (options.testSuiteConfigFile as string) || ('postman-testsuite.json' as string)
+  const testSuiteConfigFile = !includeTests
+    ? undefined
+    : options.testSuiteConfigFile || 'postman-testsuite.json'
 
   const { variableOverwrites, preRequestScripts, globalReplacements, orderOfOperations } =
     await getConfig(portmanConfigFile)
@@ -193,7 +194,7 @@ require('dotenv').config()
     outputFile: tmpCollectionFile,
     prettyPrintFlag: true,
     configFile: postmanConfigFile,
-    testSuite: includeTests || false,
+    testSuite: includeTests,
     testsuiteFile: testSuiteConfigFile,
     testFlag: tmpCollectionFile
   }

--- a/src/lib/getConfig.ts
+++ b/src/lib/getConfig.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import fs from 'fs-extra'
+import path from 'path'
 import { PortmanConfig } from 'src/types'
 
 const defaultConfig: PortmanConfig = {
@@ -12,8 +13,8 @@ const defaultConfig: PortmanConfig = {
 export const getConfig = async (configPath: string | undefined): Promise<PortmanConfig> => {
   let config = defaultConfig
 
-  if (configPath && (await fs.pathExists(configPath))) {
-    config = await import(`${__dirname}/../../${configPath}`)
+  if (configPath && (await fs.pathExists(path.resolve(configPath)))) {
+    config = await import(path.resolve(configPath))
   } else {
     console.log(chalk.red(`Portman config file not provided. Using empty default.`))
   }

--- a/src/lib/runNewmanWith.ts
+++ b/src/lib/runNewmanWith.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import newman from 'newman'
+import path from 'path'
 
 export const runNewmanWith = (
   postmanCollectionFile: string,
@@ -7,8 +8,8 @@ export const runNewmanWith = (
   newmanDataFile: string
 ): Promise<void> => {
   const newmanOptions = {
-    collection: require(`../.${postmanCollectionFile}`),
-    environment: require(`../.${newmanEnvFile}`),
+    collection: require(path.resolve(postmanCollectionFile)),
+    environment: require(path.resolve(newmanEnvFile)),
     reporters: ['cli'],
     reporter: {
       htmlextra: {
@@ -20,7 +21,7 @@ export const runNewmanWith = (
 
   if (newmanDataFile) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const iterationData = require(`../.${newmanDataFile}`)
+    const iterationData = require(path.resolve(newmanDataFile))
     newmanOptions['iterationData'] = iterationData
   }
 

--- a/src/lib/transforms/disableOptionalParams.ts
+++ b/src/lib/transforms/disableOptionalParams.ts
@@ -8,7 +8,13 @@ export const disableOptionalParams = (obj: any): any => {
     const hasQuery = resource.item.filter(({ request: { url } }) => {
       return (
         url.query.filter(({ key }) => {
-          return ['cursor', 'email', 'name'].includes(key)
+          return [
+            'cursor',
+            'filter[email]',
+            'filter[first_name]',
+            'filter[last_name]',
+            'filter[name]'
+          ].includes(key)
         }).length > 0
       )
     })
@@ -16,7 +22,15 @@ export const disableOptionalParams = (obj: any): any => {
     hasQuery &&
       hasQuery.map(item => {
         item.request.url.query.map(item => {
-          if (['cursor', 'email', 'name'].includes(item.key)) {
+          if (
+            [
+              'cursor',
+              'filter[email]',
+              'filter[first_name]',
+              'filter[last_name]',
+              'filter[name]'
+            ].includes(item.key)
+          ) {
             item.disabled = true
           }
         })


### PR DESCRIPTION
- use resolve path instead of relative
- we were providing the default to test-suite incorrectly