### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Options:
   -s, --postmanConfigFile    Path to openapi-to-postman config file (postman-config.json) [string]
   -s, --filterFile           Path to openapi-format config file (oas-format-filter.json)  [string]
   --envFile                  Path to the .env file to inject environment variables        [string]
-  --cliConfigFile            Path to Portman CLI options file                             [string]
+  --cliOptionsFile           Path to Portman CLI options file                             [string]
   --init                     Configure Portman CLI options in an interactive manner       [string]
 ```
 


### PR DESCRIPTION
The readme lists one of the options as --cliConfigFile instead of --cliOptionsFile.