### PR TITLE
Temporary fix for multiple content-types

### DIFF
--- a/CHANEGLOG.md
+++ b/CHANEGLOG.md
@@ -1,3 +1,9 @@
+## v1.3.3 - (2021-07-14)
+
+### Temporary fix
+
+- Temporary fix for handling multiple content-types, where the contract will be based on the 1st content-type that is defined in the OpenAPI response.
+
 ## v1.3.2 - (2021-07-09)
 
 ### Globals

--- a/src/application/TestSuite.ts
+++ b/src/application/TestSuite.ts
@@ -227,10 +227,16 @@ export class TestSuite {
 
     // Add response content checks
     if (responseObject.content) {
+      // TEMPORARY HANDLING of multiple content-types
+      let contentTypesCounter = 0
+
       // Process all content-types
       for (const [contentType, content] of Object.entries(responseObject.content)) {
         // Early skip if no content-types defined
         if (!contentType) continue
+
+        // TEMPORARY HANDLING of multiple content-types
+        if (contentTypesCounter > 0) continue
 
         // Add contentType check
         if (optContentType && !inOperations(pmOperation, optContentType?.excludeForOperations)) {
@@ -254,6 +260,8 @@ export class TestSuite {
         ) {
           pmOperation = testResponseJsonSchema(content?.schema, pmOperation, oaOperation)
         }
+
+        contentTypesCounter++
       }
     }
 


### PR DESCRIPTION
Temporary fix for handling multiple content-types, where the contract will be based on t he 1st content-type that is defined in the OpenAPI response.

There are a number of ways to solve this, so we are looking into an option that is easy to configure with the test injection.