### PR TITLE
Bugfix - spreadArray is not a function

### DIFF
--- a/src/application/globals/injectEnvVariables.ts
+++ b/src/application/globals/injectEnvVariables.ts
@@ -43,6 +43,6 @@ export const injectEnvVariables = (
   }
 
   variables = upsertEnvVariable(variables, 'baseUrl', baseUrl || baseUrlFromSpec, 'string')
-  obj.variable = [...new Set(variables)]
+  obj.variable = Array.from(new Set(variables))
   return obj
 }


### PR DESCRIPTION
Fix for #99, which solves "spreadArray is not a function" since the __spreadArrays function for TypeScript has been deprecated