### PR TITLE
Replace "spreadArray" with compatible implementation

### DIFF
--- a/src/application/globals/writeCollectionPreRequestScripts.ts
+++ b/src/application/globals/writeCollectionPreRequestScripts.ts
@@ -20,10 +20,15 @@ export const writeCollectionPreRequestScripts = (
   }
 
   const script = new Script(preRequestEvent.script as ScriptDefinition)
-  const exec = Array.isArray(script.exec) ? [...script.exec, ...scripts] : [script.exec, ...scripts]
+  if (script.exec === undefined) script.exec = []
+  const exec = Array.isArray(script.exec)
+    ? ([] as string[]).concat(Array.from(script.exec), Array.from(scripts))
+    : ([script.exec] as string[]).concat(Array.from(scripts))
   script.update({ exec: exec.filter(i => Boolean(i)) as string[] })
   preRequestEvent.script = script.toJSON()
-  collection.event = collection?.event ? [...collection.event, preRequestEvent] : [preRequestEvent]
+  collection.event = collection?.event
+    ? ([] as EventDefinition[]).concat(Array.from(collection.event), [preRequestEvent])
+    : [preRequestEvent]
 
   return collection
 }

--- a/src/application/overwrites/overwriteRequestPathIdVariables.ts
+++ b/src/application/overwrites/overwriteRequestPathIdVariables.ts
@@ -22,7 +22,7 @@ export const overwriteRequestPathIdVariables = (
   if (!pmOperation.item?.name) return pmOperation
 
   const pathParams = pmOperation.item.request.url?.path
-    ? [...pmOperation.item.request.url?.path]
+    ? Array.from(pmOperation.item.request.url?.path)
     : []
 
   const idIndex = pathParams.indexOf(':id')

--- a/src/application/preRequests/writeOperationPreRequestScripts.ts
+++ b/src/application/preRequests/writeOperationPreRequestScripts.ts
@@ -23,9 +23,11 @@ export const writeOperationPreRequestScripts = (
     }
 
     const script = new Script(preRequestEvent.script as ScriptDefinition)
-    const exec = Array.isArray(script.exec)
-      ? [...script.exec, ...scripts]
-      : [script.exec, ...scripts]
+    if (script.exec === undefined) script.exec = []
+    const exec =
+      script.exec && Array.isArray(script.exec)
+        ? ([] as string[]).concat(Array.from(script.exec), Array.from(scripts))
+        : ([script.exec] as string[]).concat(Array.from(scripts))
     script.update({ exec: exec.filter(i => Boolean(i)) as string[] })
     preRequestEvent.script = script.toJSON()
     operation.events.add(new Event(preRequestEvent))


### PR DESCRIPTION
The error "spreadArray is not a function" occurs because the __spreadArrays function for TypeScript has been deprecated.

This PR aims to replace the "spreadArray" usage with a compatible implementation.

Linked to #99 