### PR TITLE
Postman upload service - Handle collection name more safely

### DIFF
--- a/src/services/PostmanRepo.ts
+++ b/src/services/PostmanRepo.ts
@@ -84,7 +84,7 @@ export class PostmanRepo {
     }
 
     const results = this.cache.collections.filter(
-      collection => collection.name.toLowerCase() === name.toLowerCase()
+      collection => collection.name.toLowerCase() === name?.toLowerCase()
     )
 
     if (results.length === 0) {
@@ -118,7 +118,7 @@ export class PostmanRepo {
     }
 
     const results = this.cache.workspace.collections.filter(
-      collection => collection.name.toLowerCase() === name.toLowerCase()
+      collection => collection.name.toLowerCase() === name?.toLowerCase()
     )
 
     if (results.length === 0) {


### PR DESCRIPTION
This PR handles the collection name more safely

```
var results = this.cache.collections.filter(function (collection) { return collection.name.toLowerCase() === name.toLowerCase(); });
                                                                                                                          ^
TypeError: Cannot read properties of undefined (reading ‘toLowerCase’)
```