### PR TITLE
Fix missing Collection name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## v1.10.1 - (Unreleased)
+
+- Fixed missing collection name issue (#171)
+- Improved formatting of variation test example config (#170)
+
 ## v1.10.0 - (2021-11-15)
 
 - Overwrites - Extended the overwriteRequestHeaders capabilities with the option to insert new headers in Postman

--- a/src/Portman.ts
+++ b/src/Portman.ts
@@ -448,7 +448,7 @@ export class Portman {
       // --- Portman - Replace & clean-up Portman
       if (globals?.portmanReplacements) {
         collectionString = writeRawReplacements(collectionString, globals.portmanReplacements)
-        this.portmanCollection = new Collection(JSON.parse(collectionString))
+        this.portmanCollection = new Collection(JSON.parse(collectionString)).toJSON()
       }
 
       fs.writeFileSync(postmanCollectionFile, collectionString, 'utf8')

--- a/src/services/PostmanApiService.ts
+++ b/src/services/PostmanApiService.ts
@@ -260,7 +260,7 @@ export class PostmanApiService {
         spinner.succeed(`Upload to Postman Succeeded`)
       } else {
         spinner.succeed(
-          `Upload to Postman completed with status: ${responseStatusCode}. \n\n Please review your collection within Postman as they can respond with a 504 timeout but still import your collection`
+          `Upload to Postman completed with status: ${responseStatusCode}. \n\n Please review your collection within Postman as they can respond with a 5xx but still import your collection`
         )
       }
       return JSON.stringify({ status: 'success', data: { ...respData, collection } }, null, 2)

--- a/src/services/PostmanSyncService.ts
+++ b/src/services/PostmanSyncService.ts
@@ -46,6 +46,12 @@ export class PostmanSyncService {
     this.portmanCollection = portmanCollection
     this.collectionName = collectionName || (portmanCollection?.info?.name as string)
     this.state = {}
+
+    if (!this.collectionName) {
+      throw new Error(
+        `Postman collection name is required. Please ensure your OpenAPI document has title.`
+      )
+    }
   }
 
   public async sync(): Promise<string> {

--- a/src/services/PostmanSyncService.ts
+++ b/src/services/PostmanSyncService.ts
@@ -44,7 +44,7 @@ export class PostmanSyncService {
     this.postmanRepo = new PostmanRepo(this.cacheFile, this.postmanApi)
 
     this.portmanCollection = portmanCollection
-    this.collectionName = collectionName || (portmanCollection?.name as string)
+    this.collectionName = collectionName || (portmanCollection?.info?.name as string)
     this.state = {}
   }
 

--- a/src/services/PostmanSyncService.ts
+++ b/src/services/PostmanSyncService.ts
@@ -44,11 +44,7 @@ export class PostmanSyncService {
     this.postmanRepo = new PostmanRepo(this.cacheFile, this.postmanApi)
 
     this.portmanCollection = portmanCollection
-    this.collectionName =
-      collectionName ||
-      (portmanCollection?.name
-        ? (portmanCollection?.name as string)
-        : (portmanCollection?.info?.name as string))
+    this.collectionName = collectionName || (portmanCollection?.name as string)
     this.state = {}
   }
 

--- a/src/services/PostmanSyncService.ts
+++ b/src/services/PostmanSyncService.ts
@@ -44,7 +44,11 @@ export class PostmanSyncService {
     this.postmanRepo = new PostmanRepo(this.cacheFile, this.postmanApi)
 
     this.portmanCollection = portmanCollection
-    this.collectionName = collectionName || (portmanCollection?.name as string)
+    this.collectionName =
+      collectionName ||
+      (portmanCollection?.name
+        ? (portmanCollection?.name as string)
+        : (portmanCollection?.info?.name as string))
     this.state = {}
   }
 

--- a/src/services/PostmanSyncService.ts
+++ b/src/services/PostmanSyncService.ts
@@ -44,7 +44,7 @@ export class PostmanSyncService {
     this.postmanRepo = new PostmanRepo(this.cacheFile, this.postmanApi)
 
     this.portmanCollection = portmanCollection
-    this.collectionName = collectionName || (portmanCollection?.info?.name as string)
+    this.collectionName = collectionName || (portmanCollection?.name as string)
     this.state = {}
   }
 


### PR DESCRIPTION
This PR handles the collection name

```
var results = this.cache.collections.filter(function (collection) { return collection.name.toLowerCase() === name.toLowerCase(); });
                                                                                                                          ^
TypeError: Cannot read properties of undefined (reading ‘toLowerCase’)
```