### PR TITLE
Add support for importing files for operationPreRequestScripts and collectionPreRequestScripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ The `operationPreRequestScripts` is inserted on the request level.
 - **openApiOperation (String)** : Reference to combination of the OpenAPI method & path, for which the "Pre-request Scripts" will be inserted (example: `GET::/crm/leads`)
 - **excludeForOperations (Array | optional)** : References to OpenAPI operations that will be skipped for targeting. (example: `["leadsAdd", "GET::/crm/leads/{id}"]`)
 
-- **scripts (Array)** : Array of scripts that will be injected as Postman Pre-request Scripts on request level, that will be executed before the targeted requests in this collection.
+- **scripts (Array)** : Array of scripts that will be injected as Postman Pre-request Scripts on request level, that will be executed before the targeted requests in this collection. Values can be the script content or path to the script file (with `file:` prefix).
 
 <hr>
 
@@ -591,7 +591,7 @@ The configuration defined in the `globals` will be executed on the full Postman 
 
 #### globals options
 
-- **collectionPreRequestScripts** : Array of scripts that will be injected as Postman Collection Pre-request Scripts that will execute before every request in this collection.
+- **collectionPreRequestScripts** : Array of scripts that will be injected as Postman Collection Pre-request Scripts that will execute before every request in this collection. Values can be the script content or path to the script file (with `file:` prefix).
 - **keyValueReplacements** : A map of parameter key names that will have their values replaced with the provided Postman variables.
 - **valueReplacements** : A map of values that will have their values replaced with the provided values.
 - **rawReplacements** : Consider this a "search & replace" utility, that will search a string/object/... and replace it with another string/object/...

--- a/src/application/globals/__fixtures__/samplePreRequest1.js
+++ b/src/application/globals/__fixtures__/samplePreRequest1.js
@@ -1,0 +1,1 @@
+pm.request.headers.add({key: "header_name", value: "header_value" });

--- a/src/application/globals/__fixtures__/samplePreRequest2.js
+++ b/src/application/globals/__fixtures__/samplePreRequest2.js
@@ -1,0 +1,1 @@
+pm.collectionVariables.set("applicationId", pm.iterationData.get("applicationId") || "1111");

--- a/src/application/globals/__snapshots__/writeCollectionPreRequestScripts.test.ts.snap
+++ b/src/application/globals/__snapshots__/writeCollectionPreRequestScripts.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`writeCollectionPreRequestScripts should inject the configured PreRequestScripts from file on collection 1`] = `
+Array [
+  Array [
+    "pm.request.headers.add({key: \\"header_name\\", value: \\"header_value\\" });
+",
+    "pm.collectionVariables.set(\\"applicationId\\", pm.iterationData.get(\\"applicationId\\") || \\"1111\\");
+",
+  ],
+]
+`;
+
 exports[`writeCollectionPreRequestScripts should inject the configured PreRequestScripts on collection 1`] = `
 Array [
   Array [

--- a/src/application/globals/writeCollectionPreRequestScripts.test.ts
+++ b/src/application/globals/writeCollectionPreRequestScripts.test.ts
@@ -12,4 +12,15 @@ describe('writeCollectionPreRequestScripts', () => {
     const result = writeCollectionPreRequestScripts(collection, collectionPreRequestScripts)
     expect(result?.event && result.event.map(({ script }) => script['exec'])).toMatchSnapshot()
   })
+
+  it('should inject the configured PreRequestScripts from file on collection', async () => {
+    const collection = getPostmanCollection().toJSON()
+
+    const collectionPreRequestScripts = [
+      'file:src/application/globals/__fixtures__/samplePreRequest1.js',
+      'file:src/application/globals/__fixtures__/samplePreRequest2.js'
+    ]
+    const result = writeCollectionPreRequestScripts(collection, collectionPreRequestScripts)
+    expect(result?.event && result.event.map(({ script }) => script['exec'])).toMatchSnapshot()
+  })
 })

--- a/src/application/globals/writeCollectionPreRequestScripts.ts
+++ b/src/application/globals/writeCollectionPreRequestScripts.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import { CollectionDefinition, EventDefinition, Script, ScriptDefinition } from 'postman-collection'
 
 export const writeCollectionPreRequestScripts = (
@@ -19,11 +20,18 @@ export const writeCollectionPreRequestScripts = (
     } as EventDefinition
   }
 
+  const scriptContents = scripts.map(src => {
+    if (src.startsWith('file:')) {
+      return fs.readFileSync(src.replace('file:', ''), { encoding:'utf8', flag:'r' })
+    } else {
+      return src
+    }
+  })
   const script = new Script(preRequestEvent.script as ScriptDefinition)
   if (script.exec === undefined) script.exec = []
   const exec = Array.isArray(script.exec)
-    ? ([] as string[]).concat(Array.from(script.exec), Array.from(scripts))
-    : ([script.exec] as string[]).concat(Array.from(scripts))
+    ? ([] as string[]).concat(Array.from(script.exec), Array.from(scriptContents))
+    : ([script.exec] as string[]).concat(Array.from(scriptContents))
   script.update({ exec: exec.filter(i => Boolean(i)) as string[] })
   preRequestEvent.script = script.toJSON()
   collection.event = collection?.event

--- a/src/application/globals/writeCollectionPreRequestScripts.ts
+++ b/src/application/globals/writeCollectionPreRequestScripts.ts
@@ -22,7 +22,7 @@ export const writeCollectionPreRequestScripts = (
 
   const scriptContents = scripts.map(src => {
     if (src.startsWith('file:')) {
-      return fs.readFileSync(src.replace('file:', ''), { encoding:'utf8', flag:'r' })
+      return getScriptContent(src.replace('file:', ''))
     } else {
       return src
     }
@@ -39,4 +39,15 @@ export const writeCollectionPreRequestScripts = (
     : [preRequestEvent]
 
   return collection
+}
+
+function getScriptContent(scriptPath: string): string {
+  try {
+    return fs.readFileSync(scriptPath, { encoding:'utf8', flag:'r' })
+  } catch(ex) {
+    console.error(
+      '\x1b[31m', 
+      `Config pre-request script file error - no such file or directory "${scriptPath}"`)
+    process.exit(1)
+  }
 }

--- a/src/application/preRequests/__fixtures__/samplePreRequest1.js
+++ b/src/application/preRequests/__fixtures__/samplePreRequest1.js
@@ -1,0 +1,1 @@
+pm.request.headers.add({key: "header_name", value: "header_value" });

--- a/src/application/preRequests/__fixtures__/samplePreRequest2.js
+++ b/src/application/preRequests/__fixtures__/samplePreRequest2.js
@@ -1,0 +1,1 @@
+pm.collectionVariables.set("applicationId", pm.iterationData.get("applicationId") || "1111");

--- a/src/application/preRequests/__snapshots__/writeOperationPreRequestScripts.test.ts.snap
+++ b/src/application/preRequests/__snapshots__/writeOperationPreRequestScripts.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`writeOperationPreRequestScripts should inject the configured PreRequestScripts from file on collection 1`] = `
+Array [
+  Array [
+    "pm.request.headers.add({key: \\"header_name\\", value: \\"header_value\\" });
+",
+    "pm.collectionVariables.set(\\"applicationId\\", pm.iterationData.get(\\"applicationId\\") || \\"1111\\");
+",
+  ],
+]
+`;
+
 exports[`writeOperationPreRequestScripts should inject the configured PreRequestScripts on collection 1`] = `
 Array [
   Array [

--- a/src/application/preRequests/writeOperationPreRequestScripts.test.ts
+++ b/src/application/preRequests/writeOperationPreRequestScripts.test.ts
@@ -12,4 +12,15 @@ describe('writeOperationPreRequestScripts', () => {
     writeOperationPreRequestScripts([pmOperation], operationPreRequestScripts)
     expect(pmOperation.item.events.map(({ script }) => script['exec'])).toMatchSnapshot()
   })
+
+  it('should inject the configured PreRequestScripts from file on collection', async () => {
+    const pmOperation = await getPostmanMappedOperation()
+
+    const operationPreRequestScripts = [
+      'file:src/application/preRequests/__fixtures__/samplePreRequest1.js',
+      'file:src/application/preRequests/__fixtures__/samplePreRequest2.js'
+    ]
+    writeOperationPreRequestScripts([pmOperation], operationPreRequestScripts)
+    expect(pmOperation.item.events.map(({ script }) => script['exec'])).toMatchSnapshot()
+  })
 })

--- a/src/application/preRequests/writeOperationPreRequestScripts.ts
+++ b/src/application/preRequests/writeOperationPreRequestScripts.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs'
 import { Event, EventDefinition, EventList, Script, ScriptDefinition } from 'postman-collection'
 import { PostmanMappedOperation } from 'src/postman'
 

--- a/src/application/preRequests/writeOperationPreRequestScripts.ts
+++ b/src/application/preRequests/writeOperationPreRequestScripts.ts
@@ -25,7 +25,7 @@ export const writeOperationPreRequestScripts = (
 
     const scriptContents = scripts.map(src => {
       if (src.startsWith('file:')) {
-        return fs.readFileSync(src.replace('file:', ''), { encoding:'utf8', flag:'r' })
+        return getScriptContent(src.replace('file:', ''))
       } else {
         return src
       }
@@ -42,4 +42,15 @@ export const writeOperationPreRequestScripts = (
 
     return pmOperation
   })
+}
+
+function getScriptContent(scriptPath: string): string {
+  try {
+    return fs.readFileSync(scriptPath, { encoding:'utf8', flag:'r' })
+  } catch(ex) {
+    console.error(
+      '\x1b[31m', 
+      `Config pre-request script file error - no such file or directory "${scriptPath}"`)
+    process.exit(1)
+  }
 }

--- a/src/application/preRequests/writeOperationPreRequestScripts.ts
+++ b/src/application/preRequests/writeOperationPreRequestScripts.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { Event, EventDefinition, EventList, Script, ScriptDefinition } from 'postman-collection'
 import { PostmanMappedOperation } from 'src/postman'
 
@@ -22,12 +23,19 @@ export const writeOperationPreRequestScripts = (
       } as EventDefinition
     }
 
+    const scriptContents = scripts.map(src => {
+      if (src.startsWith('file:')) {
+        return fs.readFileSync(src.replace('file:', ''), { encoding:'utf8', flag:'r' })
+      } else {
+        return src
+      }
+    })
     const script = new Script(preRequestEvent.script as ScriptDefinition)
     if (script.exec === undefined) script.exec = []
     const exec =
       script.exec && Array.isArray(script.exec)
-        ? ([] as string[]).concat(Array.from(script.exec), Array.from(scripts))
-        : ([script.exec] as string[]).concat(Array.from(scripts))
+        ? ([] as string[]).concat(Array.from(script.exec), Array.from(scriptContents))
+        : ([script.exec] as string[]).concat(Array.from(scriptContents))
     script.update({ exec: exec.filter(i => Boolean(i)) as string[] })
     preRequestEvent.script = script.toJSON()
     operation.events.add(new Event(preRequestEvent))


### PR DESCRIPTION
Allow `collectionPreRequestScripts` and `operationPreRequestScripts` to import local script files by specifying `file:` followed by the file path, e.g. `file:scripts/auth-pre-request.js`.

**Use Case:** Our API collections have quite complex pre-request scripts. In order to manage them, currently we keep those scripts in separate files, and we have to copy their contents into portman config file manually when we make any change. 
It is quite tedious and error-prone process so I think it would be great if portman can support importing the script files out of the box.

Please let me know if this feature can be incorporated and if there is any change required for the PR.

Thanks very much for creating and maintaining this tool.

Cheers,