### PR TITLE
Valid schema when float as a format is used

### DIFF
--- a/src/application/tests/testResponseJsonSchema.ts
+++ b/src/application/tests/testResponseJsonSchema.ts
@@ -34,7 +34,7 @@ export const testResponseJsonSchema = (
     `// Validate if response matches JSON schema \n`,
     `pm.test("[${pmOperation.method.toUpperCase()}]::${pmOperation.path}`,
     ` - Schema is valid", function() {\n`,
-    `    pm.response.to.have.jsonSchema(schema,{unknownFormats: ["int32", "int64"]});\n`,
+    `    pm.response.to.have.jsonSchema(schema,{unknownFormats: ["int32", "int64", "float"]});\n`,
     `});\n`
   ].join('')
 


### PR DESCRIPTION
When float as format is used the actual tests will fail. This is addition they shouldn't.