### PR TITLE
Adapt replacements to modify json schema tests

### DIFF
--- a/src/application/globals/writeRawReplacements.test.ts
+++ b/src/application/globals/writeRawReplacements.test.ts
@@ -147,3 +147,85 @@ describe('writeRawReplacements', () => {
     })
   })
 })
+
+it('should remove found values in escaped string for schema validation if replaced with empty string', () => {
+  const config = [
+    {
+      searchFor: '"format":"date",',
+      replaceWith: ''
+    }
+  ]
+
+  const obj = {
+    event: [
+      {
+        listen: 'test',
+        script: {
+          id: 'b7904efa-d19f-424e-88aa-09829bec8643',
+          type: 'text/javascript',
+          exec: [
+            '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"date\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"date\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
+          ]
+        }
+      }
+    ]
+  }
+  const string = JSON.stringify(obj, null, 2)
+  const result = writeRawReplacements(string, config)
+  const resultObj = JSON.parse(result)
+  expect(resultObj).toStrictEqual({
+    event: [
+      {
+        listen: 'test',
+        script: {
+          id: 'b7904efa-d19f-424e-88aa-09829bec8643',
+          type: 'text/javascript',
+          exec: [
+            '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
+          ]
+        }
+      }
+    ]
+  })
+})
+
+it('should replace found values in escaped string for schema validation with correctly escaped strings', () => {
+  const config = [
+    {
+      searchFor: '"format":"date"',
+      replaceWith: '"format":"specialDate"'
+    }
+  ]
+
+  const obj = {
+    event: [
+      {
+        listen: 'test',
+        script: {
+          id: 'b7904efa-d19f-424e-88aa-09829bec8643',
+          type: 'text/javascript',
+          exec: [
+            '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"date\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"date\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
+          ]
+        }
+      }
+    ]
+  }
+  const string = JSON.stringify(obj, null, 2)
+  const result = writeRawReplacements(string, config)
+  const resultObj = JSON.parse(result)
+  expect(resultObj).toStrictEqual({
+    event: [
+      {
+        listen: 'test',
+        script: {
+          id: 'b7904efa-d19f-424e-88aa-09829bec8643',
+          type: 'text/javascript',
+          exec: [
+            '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"specialDate\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"specialDate\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
+          ]
+        }
+      }
+    ]
+  })
+})

--- a/src/application/globals/writeRawReplacements.test.ts
+++ b/src/application/globals/writeRawReplacements.test.ts
@@ -164,6 +164,8 @@ it('should remove found values in escaped string for schema validation if replac
           id: 'b7904efa-d19f-424e-88aa-09829bec8643',
           type: 'text/javascript',
           exec: [
+            // prettier-ignore
+            // eslint-disable-next-line no-useless-escape
             '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"date\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"date\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
           ]
         }
@@ -181,6 +183,8 @@ it('should remove found values in escaped string for schema validation if replac
           id: 'b7904efa-d19f-424e-88aa-09829bec8643',
           type: 'text/javascript',
           exec: [
+            // prettier-ignore
+            // eslint-disable-next-line no-useless-escape
             '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
           ]
         }
@@ -205,6 +209,8 @@ it('should replace found values in escaped string for schema validation with cor
           id: 'b7904efa-d19f-424e-88aa-09829bec8643',
           type: 'text/javascript',
           exec: [
+            // prettier-ignore
+            // eslint-disable-next-line no-useless-escape
             '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"date\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"date\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
           ]
         }
@@ -222,6 +228,8 @@ it('should replace found values in escaped string for schema validation with cor
           id: 'b7904efa-d19f-424e-88aa-09829bec8643',
           type: 'text/javascript',
           exec: [
+            // prettier-ignore
+            // eslint-disable-next-line no-useless-escape
             '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"specialDate\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"specialDate\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
           ]
         }

--- a/src/application/globals/writeRawReplacements.test.ts
+++ b/src/application/globals/writeRawReplacements.test.ts
@@ -148,7 +148,7 @@ describe('writeRawReplacements', () => {
   })
 })
 
-it('should remove found values in escaped string for schema validation if replaced with empty string', () => {
+it('should use config with quotes to remove all found values in escaped string', () => {
   const config = [
     {
       searchFor: '"format":"date",',
@@ -157,43 +157,17 @@ it('should remove found values in escaped string for schema validation if replac
   ]
 
   const obj = {
-    event: [
-      {
-        listen: 'test',
-        script: {
-          id: 'b7904efa-d19f-424e-88aa-09829bec8643',
-          type: 'text/javascript',
-          exec: [
-            // prettier-ignore
-            // eslint-disable-next-line no-useless-escape
-            '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"date\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"date\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
-          ]
-        }
-      }
-    ]
+    exec: ['... "format":"date", ...']
   }
   const string = JSON.stringify(obj, null, 2)
   const result = writeRawReplacements(string, config)
   const resultObj = JSON.parse(result)
   expect(resultObj).toStrictEqual({
-    event: [
-      {
-        listen: 'test',
-        script: {
-          id: 'b7904efa-d19f-424e-88aa-09829bec8643',
-          type: 'text/javascript',
-          exec: [
-            // prettier-ignore
-            // eslint-disable-next-line no-useless-escape
-            '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
-          ]
-        }
-      }
-    ]
+    exec: ['...  ...']
   })
 })
 
-it('should replace found values in escaped string for schema validation with correctly escaped strings', () => {
+it('should use config with quotes to replace all found values in escaped string', () => {
   const config = [
     {
       searchFor: '"format":"date"',
@@ -202,38 +176,12 @@ it('should replace found values in escaped string for schema validation with cor
   ]
 
   const obj = {
-    event: [
-      {
-        listen: 'test',
-        script: {
-          id: 'b7904efa-d19f-424e-88aa-09829bec8643',
-          type: 'text/javascript',
-          exec: [
-            // prettier-ignore
-            // eslint-disable-next-line no-useless-escape
-            '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"date\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"date\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
-          ]
-        }
-      }
-    ]
+    exec: ['... "format":"date", ...']
   }
   const string = JSON.stringify(obj, null, 2)
   const result = writeRawReplacements(string, config)
   const resultObj = JSON.parse(result)
   expect(resultObj).toStrictEqual({
-    event: [
-      {
-        listen: 'test',
-        script: {
-          id: 'b7904efa-d19f-424e-88aa-09829bec8643',
-          type: 'text/javascript',
-          exec: [
-            // prettier-ignore
-            // eslint-disable-next-line no-useless-escape
-            '// Response Validation\nconst schema = {\"title\":\"User\",\"type\":\"object\",\"description\":\"\",\"examples\":[{\"id\":142,\"firstName\":\"Alice\",\"dateOfBirth\":\"1997-10-31\",\"signUpDate\":\"2019-08-24\"}],\"properties\":{\"id\":{\"type\":\"integer\"},\"firstName\":{\"type\":\"string\"},\"dateOfBirth\":{\"type\":\"string\",\"format\":\"specialDate\",\"example\":\"1997-10-31\"},\"signUpDate\":{\"type\":\"string\",\"format\":\"specialDate\",\"description\":\"The date that the user was created.\"}},\"required\":[\"id\",\"firstName\"]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/user - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n'
-          ]
-        }
-      }
-    ]
+    exec: ['... "format":"specialDate", ...']
   })
 })

--- a/src/application/globals/writeRawReplacements.ts
+++ b/src/application/globals/writeRawReplacements.ts
@@ -6,7 +6,7 @@ export const writeRawReplacements = (
   globalReplacements: GlobalReplacement[]
 ): string => {
   globalReplacements.map(({ searchFor, replaceWith }) => {
-    const pattern = searchFor.replace(/"/g, '\\\\"')
+    const pattern = searchFor.replace(/"/g, '\\"')
     const replacement = replaceWith.replace(/"/g, '\\"')
     collectionAsString = collectionAsString.replace(
       new RegExp(escapeRegExp(pattern), 'g'),


### PR DESCRIPTION
When using Portman, we wanted to use replacements to modify the generated JSON schema tests. However, we couldn't get it to work as described in the documentation.

To test our use cases, I added two tests which either replace parts of the JSON schema with an empty string (to delete parts) or another string (to modify parts). I then corrected the used pattern in the writeRawReplacements function to make the tests pass.