### PR TITLE
Fix passing Newman options during Newman execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix Newman option not properly formatted (#395)
+
 ## v1.18.0 - (2022-07-19)
 
 - Overwrites - Automatically convert values for request query parameters, path variables & headers to string (#336, #384)

--- a/src/application/newman/runNewmanWith.ts
+++ b/src/application/newman/runNewmanWith.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import newman, { NewmanRunOptions } from 'newman'
 import path from 'path'
+import { camelCase } from 'camel-case'
 
 export const runNewmanWith = async (
   postmanCollectionFile: string,
@@ -26,8 +27,13 @@ export const runNewmanWith = async (
     const iterationData = require(path.resolve(newmanDataFile))
     defaultNewmanOptions['iterationData'] = iterationData
   }
-
-  const newmanOptions = { ...defaultNewmanOptions, ...newmanRunOptions }
+  // camelCase Newman run options
+  const newmanRunOptionsCased = Object.keys(newmanRunOptions).reduce(
+    (a, c) => ((a[`${camelCase(c)}`] = newmanRunOptions[c]), a),
+    {}
+  ) as Partial<NewmanRunOptions>
+  // Merge Newman default and runtime options
+  const newmanOptions = { ...defaultNewmanOptions, ...newmanRunOptionsCased }
 
   return new Promise((resolve, reject) => {
     try {


### PR DESCRIPTION
The Newman CLI expects options as param-cased, while when using Newman as a NodeJS module the options are camelCase