### PR TITLE
Fix folder name

### DIFF
--- a/src/application/IntegrationTestWriter.ts
+++ b/src/application/IntegrationTestWriter.ts
@@ -41,7 +41,7 @@ export class IntegrationTestWriter {
 
       if (!pmOperation) return
 
-      const folderId = pmOperation.getParentFolderId()
+      const folderId = variationWriter.variationFolder.id
       // const folderName = pmOperation.getParentFolderName()
 
       const oaOperation = testSuite.oasParser.getOperationByPath(pmOperation.pathRef)


### PR DESCRIPTION
Generates multiple file names for the same integration test folder, because it's using the folder id from the operation.