### PR TITLE
fix: overwriteRequestBaseUrl - overwrite value with path parameters excludes parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "faker": "^5.5.3",
         "fp-ts": "^2.12.3",
         "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
         "newman": "^5.3.2",
         "node-emoji": "^1.11.0",
         "openapi-format": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "faker": "^5.5.3",
     "fp-ts": "^2.12.3",
     "fs-extra": "^10.1.0",
+    "lodash": "^4.17.21",
     "newman": "^5.3.2",
     "node-emoji": "^1.11.0",
     "openapi-format": "^1.13.0",

--- a/src/application/overwrites/__snapshots__/overwriteRequestBaseUrl.test.ts.snap
+++ b/src/application/overwrites/__snapshots__/overwriteRequestBaseUrl.test.ts.snap
@@ -259,6 +259,43 @@ Object {
 }
 `;
 
+exports[`overwriteRequestBaseUrl should overwrite the request base url with a variable and path 1`] = `
+Object {
+  "host": Array [
+    "{{foo-bar-baz}}",
+  ],
+  "path": Array [
+    "path",
+    "crm",
+    "companies",
+    ":id",
+  ],
+  "query": Array [
+    Object {
+      "description": Object {
+        "content": "Include raw response. Mostly used for debugging purposes",
+        "type": "text/plain",
+      },
+      "disabled": false,
+      "key": "raw",
+      "value": "true",
+    },
+  ],
+  "variable": Array [
+    Object {
+      "description": Object {
+        "content": "(Required) ID of the record you are acting upon.",
+        "type": "text/plain",
+      },
+      "disabled": false,
+      "key": "id",
+      "type": "any",
+      "value": "123456",
+    },
+  ],
+}
+`;
+
 exports[`overwriteRequestBaseUrl should remove the request base url when remove is true 1`] = `
 Object {
   "path": Array [

--- a/src/application/overwrites/overwriteRequestBaseUrl.test.ts
+++ b/src/application/overwrites/overwriteRequestBaseUrl.test.ts
@@ -89,4 +89,20 @@ describe('overwriteRequestBaseUrl', () => {
     expect(result.item.request.url.getHost()).toBe('')
     expect(result.item.request.url).toMatchSnapshot()
   })
+
+  it('should overwrite the request base url with a variable and path', async () => {
+    const overwriteValue = {
+      value: '{{foo-bar-baz}}/path'
+    }
+
+    const pmOperation = await getPostmanMappedOperation()
+    const result = overwriteRequestBaseUrl(overwriteValue, pmOperation)
+    expect(result.item.request.url.getHost()).toBe('{{foo-bar-baz}}')
+    expect(result.item.request.url.path).toBeDefined()
+    expect(result.item.request.url.path?.length).toEqual(4)
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(result.item.request.url.path[0]).toEqual('path')
+    expect(result.item.request.url).toMatchSnapshot()
+  })
 })

--- a/src/application/overwrites/overwriteRequestBaseUrl.ts
+++ b/src/application/overwrites/overwriteRequestBaseUrl.ts
@@ -1,5 +1,6 @@
 import { PostmanMappedOperation } from '../../postman'
 import { OverwriteRequestBaseUrlConfig } from '../../types'
+import { isEqual } from 'lodash'
 // import { Header } from 'postman-collection'
 
 /**
@@ -31,10 +32,17 @@ export const overwriteRequestBaseUrl = (
     newPm.item.request.url.update('')
   }
 
-  // Update protocol, host & port
+  // Update protocol, host, port & path
   pmOperation.item.request.url.protocol = newPm.item.request.url.protocol
   pmOperation.item.request.url.port = newPm.item.request.url.port
   pmOperation.item.request.url.host = newPm.item.request.url.host
+  // if they are equal then no path was provided in the overwrite value
+  if (!isEqual(pmOperation.item.request.url.path, newPm.item.request.url.path)) {
+    pmOperation.item.request.url.path = [
+      ...(newPm.item.request.url.path ?? []),
+      ...(pmOperation.item.request.url.path ?? [])
+    ]
+  }
 
   return pmOperation
 }


### PR DESCRIPTION
When the `overwriteRequestBaseUrl` has a path parameter it is not included in the overwrite. For example,

`{{newUrl}}/subPath` will result in a host of `{{newUrl}}` while `subPath` will be discarded. This change will include `subPath` at the start of the `path` array in the postman spec