### PR TITLE
overwriteRequestSecurity - Keep API key when no key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- securityOverwrites - Set auth settings when no auth is defined (#472)
 - overwriteRequestSecurity - Keep API key when no key is provided (#468)
 - orderOfOperations - Prevent error (#467)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- overwriteRequestSecurity - Keep API key when no key is provided (#468)
+- orderOfOperations - Prevent error (#467)
+
 ## v1.21.0 - (2023-02-27)
 
 - Bumped openapi-to-postman to 4.9.0 which support OpenAPI 3.1

--- a/src/application/overwrites/__snapshots__/overwriteRequestSecurity.test.ts.snap
+++ b/src/application/overwrites/__snapshots__/overwriteRequestSecurity.test.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`overwriteRequestSecurity should overwrite only the request apiKey value 1`] = `
+Object {
+  "apikey": Array [
+    Object {
+      "key": "key",
+      "type": "any",
+      "value": "x-apideck-app-id",
+    },
+    Object {
+      "key": "value",
+      "type": "any",
+      "value": "foo-bar",
+    },
+  ],
+  "bearer": Array [
+    Object {
+      "key": "token",
+      "type": "any",
+      "value": "<Bearer Token>",
+    },
+  ],
+  "type": "apikey",
+}
+`;
+
 exports[`overwriteRequestSecurity should overwrite the request apiKey definition 1`] = `
 Object {
   "apikey": Array [

--- a/src/application/overwrites/overwriteRequestSecurity.test.ts
+++ b/src/application/overwrites/overwriteRequestSecurity.test.ts
@@ -26,6 +26,26 @@ describe('overwriteRequestSecurity', () => {
     expect(pmOperation.item.getAuth()).toMatchSnapshot()
   })
 
+  it('should overwrite only the request apiKey value', async () => {
+    const pmOperation = await getPostmanMappedOperation()
+
+    const overwriteValues = {
+      apiKey: {
+        key: 'x-apideck-app-id',
+        value: '{{apiKey}}'
+      }
+    }
+    overwriteRequestSecurity(overwriteValues, pmOperation)
+
+    const overwriteOnlyValue = {
+      apiKey: {
+        value: 'foo-bar'
+      }
+    }
+    overwriteRequestSecurity(overwriteOnlyValue, pmOperation)
+    expect(pmOperation.item.getAuth()).toMatchSnapshot()
+  })
+
   it('should overwrite the request bearer token auth', async () => {
     const overwriteValues = {
       bearer: {

--- a/src/application/overwrites/overwriteRequestSecurity.ts
+++ b/src/application/overwrites/overwriteRequestSecurity.ts
@@ -18,6 +18,18 @@ export const overwriteRequestSecurity = (
     authDefinition = { ...overwrite.other }
   }
 
+  // Get the current auth method
+  const authConfig = pmOperation.item.getAuth()
+
+  // Check if the current auth method matches the type we want to overwrite
+  if (authConfig.type === authDefinition.type) {
+    const members = authConfig[authDefinition.type]?.members?.reduce((acc, member) => {
+      acc[member.key] = member.value
+      return acc
+    }, {})
+    authDefinition = { ...members, ...authDefinition }
+  }
+
   authDefinition && pmOperation.item.request.authorizeUsing({ ...authDefinition })
 
   return pmOperation


### PR DESCRIPTION
Linked to #468