### PR TITLE
Adjusted ordering string matching to be exact when wildcard is not pr…

### DIFF
--- a/src/application/globals/__snapshots__/orderCollectionRequests.test.ts.snap
+++ b/src/application/globals/__snapshots__/orderCollectionRequests.test.ts.snap
@@ -303,6 +303,28 @@ Object {
       },
     },
     Object {
+      "_portman_operation": "POST::/crm/:id/status",
+      "request": Object {
+        "method": "POST",
+        "url": Object {
+          "path": Array [
+            "crm",
+            ":id",
+            "status",
+          ],
+          "variable": Array [
+            Object {
+              "description": "(Required) ID of the monkey you are acting upon.",
+              "disabled": false,
+              "key": "id",
+              "type": "any",
+              "value": "<string>",
+            },
+          ],
+        },
+      },
+    },
+    Object {
       "_portman_operation": "GET::/crm/monkies/:id",
       "request": Object {
         "method": "GET",

--- a/src/application/globals/orderCollectionRequests.test.ts
+++ b/src/application/globals/orderCollectionRequests.test.ts
@@ -118,6 +118,7 @@ describe('orderCollectionRequests()', () => {
       'POST::/crm/{id}',
       'POST::/crm/monkies/{id}',
       'GET::/crm/{crmId}/monkies/{id}',
+      'POST::/crm/{id}/status',
       'GET::/crm/monkies/{id}'
     ]
     const obj = {
@@ -137,6 +138,23 @@ describe('orderCollectionRequests()', () => {
               ]
             },
             method: 'GET'
+          }
+        },
+        {
+          request: {
+            url: {
+              path: ['crm', ':id', 'status'],
+              variable: [
+                {
+                  disabled: false,
+                  type: 'any',
+                  value: '<string>',
+                  key: 'id',
+                  description: '(Required) ID of the monkey you are acting upon.'
+                }
+              ]
+            },
+            method: 'POST'
           }
         },
         {

--- a/src/application/globals/orderCollectionRequests.ts
+++ b/src/application/globals/orderCollectionRequests.ts
@@ -3,9 +3,13 @@ export const orderCollectionRequests = (obj: any, orderOfOperations: any = []): 
   // Normalize orderOfOperations ({id}) to match with Postman format (:id)
   const regStart = new RegExp('{', 'g')
   const regEnd = new RegExp('}', 'g')
-  const orderOfOperationsNorm = orderOfOperations.map(item =>
-    item.replace(regStart, ':').replace(regEnd, '')
-  )
+  const regEx = new RegExp('/', 'g')
+  const orderOfOperationsNorm = orderOfOperations.map(item => {
+    item = item.replace(regStart, ':').replace(regEnd, '').replace(regEx, '/')
+
+    // Add string terminator for exact match if not wildcarded
+    return item.endsWith('*') ? item : `${item}$`
+  })
 
   // Sort requests in folders
   obj.item.map(pmFolder => {
@@ -61,9 +65,8 @@ const propComparatorPortmanOperation = (priorityArr: any): any => {
     if (!Array.isArray(priorityArr)) {
       return 0
     }
-    const regEx = new RegExp('/', 'g')
-    const ia = priorityArr.findIndex(pri => a['_portman_operation'].match(pri.replace(regEx, '/')))
-    const ib = priorityArr.findIndex(pri => b['_portman_operation'].match(pri.replace(regEx, '/')))
+    const ia = priorityArr.findIndex(pri => a['_portman_operation'].match(pri))
+    const ib = priorityArr.findIndex(pri => b['_portman_operation'].match(pri))
     if (ia !== -1) {
       return ib !== -1 ? ia - ib : -1
     }


### PR DESCRIPTION
I encountered an issue with orderOfOperations that appear to stem from issue https://github.com/apideck-libraries/portman/issues/122 and the fix https://github.com/apideck-libraries/portman/pull/216.
The matching for ordering was performing a starts with match, which would cause `GET::/endpoint/:id` to also match `GET::/endpoint/:id/someOtherEndpoint`, which threw off any other operations I have would between the two.

I experienced some success locally with adding a string terminator to the regex matching, so that non-wildcard entries would expect match operation.