### PR TITLE
Fix #513: Exclude properties with reserved names.

### DIFF
--- a/src/application/Fuzzer.test.ts
+++ b/src/application/Fuzzer.test.ts
@@ -1739,6 +1739,72 @@ describe('Fuzzer', () => {
     expect(result).toMatchSnapshot()
   })
 
+  it('should analyse JSON schema of request body with properties named after reserved words for fuzz detection', async () => {
+    // Analyse JSON schema with properties that use reserved words
+    const schema = {
+      properties: {
+        nullable: {
+          type: 'object',
+          properties: {
+            nullable: {
+              type: 'boolean',
+              example: true
+            }
+          }
+        },
+        required: {
+          type: 'object',
+          properties: {
+            nullable: {
+              type: 'boolean',
+              example: true
+            }
+          }
+        },
+        maximum: {
+          type: 'object',
+          properties: {
+            nullable: {
+              type: 'boolean',
+              example: true
+            }
+          }
+        },
+        minimum: {
+          type: 'object',
+          properties: {
+            nullable: {
+              type: 'boolean',
+              example: true
+            }
+          }
+        },
+        maxLength: {
+          type: 'object',
+          properties: {
+            nullable: {
+              type: 'boolean',
+              example: true
+            }
+          }
+        },
+        minLength: {
+          type: 'object',
+          properties: {
+            nullable: {
+              type: 'boolean',
+              example: true
+            }
+          }
+        }
+      },
+      required: ['nullable', 'required', 'maximum', 'minimum', 'maxLength', 'minLength']
+    } as OpenAPIV3.SchemaObject
+
+    const result = fuzzer.analyzeFuzzJsonSchema(schema)
+    expect(result).toMatchSnapshot()
+  })
+
   it('should analyse the request query param for fuzz detection', async () => {
     // Analyse query param
     const reqQueryParams = oaOpQuery?.queryParams as unknown as OpenAPIV3.ParameterObject[]

--- a/src/application/Fuzzer.ts
+++ b/src/application/Fuzzer.ts
@@ -884,9 +884,12 @@ export class Fuzzer {
         if (node?.type === 'object' && this.key && !skipSchemaKeys.includes(this.key)) {
           requiredPath += `${this.key}.`
         }
-        // Register fuzz-able required fields
-        const requiredFuzz = node.required.map(req => `${requiredPath}${req}`)
-        fuzzItems.requiredFields = fuzzItems.requiredFields.concat(requiredFuzz) || []
+
+        // Register fuzz-able required fields from the 'required' element on an object; exclude properties named 'required'.
+        if (this.key !== 'properties') {
+          const requiredFuzz = node.required.map(req => `${requiredPath}${req}`)
+          fuzzItems.requiredFields = fuzzItems.requiredFields.concat(requiredFuzz) || []
+        }
       }
 
       // Unregister fuzz-able nullable required fields
@@ -896,34 +899,36 @@ export class Fuzzer {
         )
       }
 
-      // Register all fuzz-able items
-      if (node?.minimum) {
-        fuzzItems?.minimumNumberFields?.push({
-          path: `${path}${this.key}`,
-          field: this.key,
-          value: node.minimum
-        })
-      }
-      if (node?.maximum) {
-        fuzzItems?.maximumNumberFields?.push({
-          path: `${path}${this.key}`,
-          field: this.key,
-          value: node.maximum
-        })
-      }
-      if (node?.minLength && !node?.type?.includes('object')) {
-        fuzzItems?.minLengthFields?.push({
-          path: `${path}${this.key}`,
-          field: this.key,
-          value: node.minLength
-        })
-      }
-      if (node?.maxLength && !node?.type?.includes('object')) {
-        fuzzItems?.maxLengthFields?.push({
-          path: `${path}${this.key}`,
-          field: this.key,
-          value: node.maxLength
-        })
+      // Register all fuzz-able items, excluding properties that are named after reserved words.
+      if (this.key !== 'properties') {
+        if (node?.minimum) {
+          fuzzItems?.minimumNumberFields?.push({
+            path: `${path}${this.key}`,
+            field: this.key,
+            value: node.minimum
+          })
+        }
+        if (node?.maximum) {
+          fuzzItems?.maximumNumberFields?.push({
+            path: `${path}${this.key}`,
+            field: this.key,
+            value: node.maximum
+          })
+        }
+        if (node?.minLength && !node?.type?.includes('object')) {
+          fuzzItems?.minLengthFields?.push({
+            path: `${path}${this.key}`,
+            field: this.key,
+            value: node.minLength
+          })
+        }
+        if (node?.maxLength && !node?.type?.includes('object')) {
+          fuzzItems?.maxLengthFields?.push({
+            path: `${path}${this.key}`,
+            field: this.key,
+            value: node.maxLength
+          })
+        }
       }
     })
 

--- a/src/application/__snapshots__/Fuzzer.test.ts.snap
+++ b/src/application/__snapshots__/Fuzzer.test.ts.snap
@@ -543,6 +543,24 @@ Object {
 }
 `;
 
+exports[`Fuzzer should analyse JSON schema of request body with properties named after reserved words for fuzz detection 1`] = `
+Object {
+  "fuzzType": "requestBody",
+  "maxLengthFields": Array [],
+  "maximumNumberFields": Array [],
+  "minLengthFields": Array [],
+  "minimumNumberFields": Array [],
+  "requiredFields": Array [
+    "nullable",
+    "required",
+    "maximum",
+    "minimum",
+    "maxLength",
+    "minLength",
+  ],
+}
+`;
+
 exports[`Fuzzer should analyse allOf JSON schema of request body with a mix of nested items for fuzz detection with nullable property 1`] = `
 Object {
   "fuzzType": "requestBody",


### PR DESCRIPTION
Instructs the fuzzer to treat properties with reserved names as properties instead of meta keywords that guide test generation. For example, a property called 'required' should be seen as a property and not the list of required properties on an object.