### PR TITLE
fix(collection): set no limit to the body size on collection update

### DIFF
--- a/src/services/PostmanApiService.ts
+++ b/src/services/PostmanApiService.ts
@@ -231,6 +231,8 @@ export class PostmanApiService {
     const config = {
       method: 'put',
       url: `${this.baseUrl}/collections/${postmanUid}${workspaceIdParam}`,
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': this.apiKey


### PR DESCRIPTION
The following change resolves the `ERR_FR_MAX_BODY_LENGTH_EXCEEDED` error, which happens if the source file is 3.6 MB. 

Command: 
portman -u https://fake.swagger.cloud/documentation/json  --collectionName "Test" --syncPostman --postmanFastSync

<img width="1617" alt="image" src="https://github.com/apideck-libraries/portman/assets/23310648/8f95670e-40be-42f1-85f3-dcd94cf55e68">