### PR TITLE
fix: overwriteRequestBody root should overwrite

### DIFF
--- a/src/application/overwrites/__snapshots__/overwriteRequestBody.test.ts.snap
+++ b/src/application/overwrites/__snapshots__/overwriteRequestBody.test.ts.snap
@@ -1751,7 +1751,7 @@ Array [
 ]
 `;
 
-exports[`overwriteRequestBody should extend the root request body 1`] = `
+exports[`overwriteRequestBody should extend the root request body when overwrite is false 1`] = `
 "{
     \\"name\\": \\"Copper\\",
     \\"owner_id\\": \\"12345\\",
@@ -4149,6 +4149,12 @@ Array [
     "value": "foo",
   },
 ]
+`;
+
+exports[`overwriteRequestBody should overwrite the root request body when overwrite is true 1`] = `
+"{
+    \\"foo\\": \\"foo-bar-baz\\"
+}"
 `;
 
 exports[`overwriteRequestBody should overwrite the urlencoded form boolean variable with string value 1`] = `

--- a/src/application/overwrites/overwriteRequestBody.test.ts
+++ b/src/application/overwrites/overwriteRequestBody.test.ts
@@ -11,11 +11,25 @@ import {
 } from '../../application'
 
 describe('overwriteRequestBody', () => {
-  it('should extend the root request body', async () => {
+  it('should overwrite the root request body when overwrite is true', async () => {
     const overwriteValues = [
       {
         key: '.',
-        value: { foo: 'foo-bar-baz' }
+        value: { foo: 'foo-bar-baz' },
+        overwrite: true
+      }
+    ]
+    const pmOperation = await getPostmanMappedCreateOperation()
+    const result = overwriteRequestBody(overwriteValues, pmOperation)
+    expect(result.item.request?.body?.raw).toMatchSnapshot()
+  })
+
+  it('should extend the root request body when overwrite is false', async () => {
+    const overwriteValues = [
+      {
+        key: '.',
+        value: { foo: 'foo-bar-baz' },
+        overwrite: false
       }
     ]
     const pmOperation = await getPostmanMappedCreateOperation()

--- a/src/application/overwrites/overwriteRequestBody.ts
+++ b/src/application/overwrites/overwriteRequestBody.ts
@@ -65,15 +65,17 @@ export const overwriteRequestBodyJson = (
         if (Array.isArray(originalValue) && Array.isArray(newValue)) {
           newValue = originalValue.concat(newValue)
         } else if (isObject(originalValue)) {
-          newValue = { ...(originalValue as Record<string, unknown>), newValue }
+          newValue = { ...(originalValue as Record<string, unknown>), ...newValue }
         } else {
           newValue = originalValue + newValue
         }
       }
 
-      bodyData = root
-        ? { ...bodyData, ...newValue }
-        : setByPath(bodyData, overwriteValue.key, newValue)
+      if (root) {
+        bodyData = overwriteValue.overwrite ? newValue : { ...bodyData, ...newValue }
+      } else {
+        bodyData = setByPath(bodyData, overwriteValue.key, newValue)
+      }
     }
 
     if (overwriteValue.key && overwriteValue.remove === true) {


### PR DESCRIPTION
`overwriteRequestBody` isn't taking the `overwrite` flag into account when overwriting the root (`.`). It's my understanding from the docs that the request body should only be merged when `overwrite` is `false`.

Fixes https://github.com/apideck-libraries/portman/issues/480