### PR TITLE
removes extra parameters from url when processing

### DIFF
--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -9,7 +9,7 @@ export class DownloadService {
         url: url,
         responseType: 'stream'
       })
-      const fileName = url.replace(/\/$/, '').split('/').pop()
+      const fileName = url.replace(/\/$/, '').split('?')[0].split('/').pop();
       const filePath = `./tmp/${fileName}`
 
       return await new Promise((resolve, reject) => {


### PR DESCRIPTION
In the current version of Portman if the API spec URL includes extra parameters/query strings, then the generated file name includes those parameters and Portman can't use the file in that format. I suggest to change it so that extra query parameters can be removed, when processing the URL and generating file from it.