### PR TITLE
remove references to /pets

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,15 +339,15 @@ the methods & path definitions.
 REMARK: Be sure to put quotes around the target definition.
 
 - **Strict matching** example: `"openApiOperation": "GET::/crm/leads",`
-  This will target only the "GET" method and the specific path "/pets"
+  This will target only the "GET" method and the specific path "/crm/leads"
 
 - **Method wildcard matching** example: `"openApiOperation": "*::/crm/leads",`
   This will target all methods ('get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace') and the specific
-  path "/pets"
+  path "/crm/leads"
 
 - **Path wildcard matching** example: `"openApiOperation": "GET::/crm/*"`
-  This will target only the "GET" method and any path matching any folder behind the "/pets", like "/pets/123" and
-  "/pets/123/buy".
+  This will target only the "GET" method and any path matching any folder behind the "/crm", like "/crm/companies" and
+  "/crm/leads".
 
 - **Method & Path wildcard matching** example: `"openApiOperation": "*::/crm/*",`
   A combination of wildcards for the method and path parts is even possible.

--- a/examples/testsuite-assign-overwrite/readme.md
+++ b/examples/testsuite-assign-overwrite/readme.md
@@ -36,9 +36,9 @@ To facilitate automation, we provide the option to set Postman collection variab
 ### Target options:
 
 - **openApiOperationId (String)** : Reference to the OpenAPI operationId for which the Postman pm.collectionVariables variable
-  will be set. (example: `listPets`)
+  will be set. (example: `contactsAll`)
 - **openApiOperation (String)** : Reference to the combination of the OpenAPI method & path, for which the Postman
-  pm.collectionVariables will be set. (example: `GET::/pets`)
+  pm.collectionVariables will be set. (example: `GET::/crm/contacts`)
 
 These target options are both supported for defining a target. In case both are set for the same target, only the `openApiOperationId` will be used for overwrites.
 

--- a/examples/testsuite-assign-variables/readme.md
+++ b/examples/testsuite-assign-variables/readme.md
@@ -36,9 +36,9 @@ To facilitate automation, we provide the option to set Postman collection variab
 ### Target options:
 
 - **openApiOperationId (String)** : Reference to the OpenAPI operationId for which the Postman pm.collectionVariables variable
-  will be set. (example: `listPets`)
+  will be set. (example: `leadsAll`)
 - **openApiOperation (String)** : Reference to the combination of the OpenAPI method & path, for which the Postman
-  pm.collectionVariables will be set. (example: `GET::/pets`)
+  pm.collectionVariables will be set. (example: `GET::/crm/leads`)
 
 These target options are both supported for defining a target. In case both are set for the same target, only the `openApiOperationId` will be used for overwrites.
 


### PR DESCRIPTION
It looks like an earlier version of the docs used the standard Swagger pets API spec for example. 

The latest docs now reference operations from the CRM spec, but in a few places still refer back to /pets endpoints.