### PR TITLE
Update getting started -- feedback welcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,28 +32,42 @@ With Portman, you can:
   - [x] Support for OpenAPI 3.1 (beta)
 - Extend the Postman collection with capabilities
   - [x] Assign collection variables
-  - [x] Inject Postman Contract Tests
-  - [x] Inject Postman Variation Tests
+  - [x] Inject Postman Contract Tests - [learn more](./examples/testsuite-contract-tests/readme.md)
+  - [x] Inject Postman Variation Tests - [learn more](./examples/testsuite-variation-tests/readme.md)
   - [x] Inject Postman Integration Tests
   - [x] Inject Postman with Pre-request & Tests scripts on a collection or operation level
-  - [x] Modify Postman requests
-  - [x] Fuzz Postman requests
-- [x] Upload the Postman collection to your Postman app
-- [x] Test the Postman collection with Newman
+  - [x] Modify Postman requests - learn more [here](./examples/testsuite-assign-variables/readme.md) and [here](./examples/testsuite-overwrites/readme.md)
+  - [x] Fuzz Postman requests - [learn more](./examples/testsuite-fuzzing-tests/readme.md)
+- [x] Upload the Postman collection to your Postman app - [learn more](#configure-automatic-upload-to-postman-app)
+- [x] Test the Postman collection with Newman - [learn more](#run-newman-with-newman-options)
 - [x] Split the configuration into multiple files using $ref
-- [x] Manage everything in config file for easy local or CI/CD usage
+- [x] Manage everything in config file for easy local or CI/CD usage - [learn more](#pass-all-cli-options-as-jsonyaml-file)
 
 ## Getting started
 
-1. Install Portman
+1. [Install Portman](#installation)
 2. Initialize Portman CLI configuration by running: `$ portman --init`
 
 OR
 
-1. Install Portman
+1. [Install Portman](#installation)
 2. Copy `.env.example` to `.env` and add environment variables you need available to your collection
 3. Copy/rename and customize each of the \_\_\_\_.default.json config files in the root directory to suit your needs
 4. Start converting your OpenAPI document to Postman
+
+OR
+
+If you have an existing OpenaAPI specification, try running Portman without any special setup to see how it can generate a Postman collection with contract tests with it's default configuration.
+
+1. [Install Portman](#installation)
+2. Run portman on your OpenAPI spec, ie: 
+- `npx portman -l my-openapi-spec.yaml` 
+- (if your spec is hosted use the `-u` parameter, ie:
+  - `npx portman -u https://petstore3.swagger.io/api/v3/openapi.json`
+
+This will generate a postman collection that contains a request for every method:endpoint combination defined in your spec, and include a set of "Contract Tests" for each one.  You can learn more about contract tests, and how to examine the generated collection [here](./examples/testsuite-contract-tests/readme.md).
+
+(Running portman with no explicit configuration is the same as running it with [this configuration file](./examples/testsuite-contract-tests/default-portman-config.json))
 
 All configuration options to convert from OpenAPI to Postman can be found in the [openapi-to-postman](https://github.com/postmanlabs/openapi-to-postman/blob/develop/OPTIONS.md) package documentation.
 All configuration options to filter flags/tags/methods/operations/... from OpenAPI can be found in the [openapi-format](https://github.com/thim81/openapi-format#openapi-filter-options) package documentation.

--- a/README.md
+++ b/README.md
@@ -339,15 +339,15 @@ the methods & path definitions.
 REMARK: Be sure to put quotes around the target definition.
 
 - **Strict matching** example: `"openApiOperation": "GET::/crm/leads",`
-  This will target only the "GET" method and the specific path "/pets"
+  This will target only the "GET" method and the specific path "/crm/leads"
 
 - **Method wildcard matching** example: `"openApiOperation": "*::/crm/leads",`
   This will target all methods ('get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace') and the specific
-  path "/pets"
+  path "/crm/leads"
 
 - **Path wildcard matching** example: `"openApiOperation": "GET::/crm/*"`
-  This will target only the "GET" method and any path matching any folder behind the "/pets", like "/pets/123" and
-  "/pets/123/buy".
+  This will target only the "GET" method and any path matching any folder behind the "/crm", like "/crm/companies" and
+  "/crm/leads".
 
 - **Method & Path wildcard matching** example: `"openApiOperation": "*::/crm/*",`
   A combination of wildcards for the method and path parts is even possible.

--- a/examples/testsuite-assign-overwrite/readme.md
+++ b/examples/testsuite-assign-overwrite/readme.md
@@ -36,9 +36,9 @@ To facilitate automation, we provide the option to set Postman collection variab
 ### Target options:
 
 - **openApiOperationId (String)** : Reference to the OpenAPI operationId for which the Postman pm.collectionVariables variable
-  will be set. (example: `listPets`)
+  will be set. (example: `contactsAll`)
 - **openApiOperation (String)** : Reference to the combination of the OpenAPI method & path, for which the Postman
-  pm.collectionVariables will be set. (example: `GET::/pets`)
+  pm.collectionVariables will be set. (example: `GET::/crm/contacts`)
 
 These target options are both supported for defining a target. In case both are set for the same target, only the `openApiOperationId` will be used for overwrites.
 

--- a/examples/testsuite-assign-variables/readme.md
+++ b/examples/testsuite-assign-variables/readme.md
@@ -36,9 +36,9 @@ To facilitate automation, we provide the option to set Postman collection variab
 ### Target options:
 
 - **openApiOperationId (String)** : Reference to the OpenAPI operationId for which the Postman pm.collectionVariables variable
-  will be set. (example: `listPets`)
+  will be set. (example: `leadsAll`)
 - **openApiOperation (String)** : Reference to the combination of the OpenAPI method & path, for which the Postman
-  pm.collectionVariables will be set. (example: `GET::/pets`)
+  pm.collectionVariables will be set. (example: `GET::/crm/leads`)
 
 These target options are both supported for defining a target. In case both are set for the same target, only the `openApiOperationId` will be used for overwrites.
 

--- a/examples/testsuite-contract-tests/default-portman-config.json
+++ b/examples/testsuite-contract-tests/default-portman-config.json
@@ -1,0 +1,22 @@
+{
+    "version": 1,
+    "tests": {
+        "contractTests": [
+            {
+                "openApiOperation": "*::/*",
+                "statusSuccess": {
+                    "enabled": true
+                },
+                "contentType": {
+                    "enabled": true
+                },
+                "jsonBody": {
+                    "enabled": true
+                },
+                "schemaValidation": {
+                    "enabled": true
+                }
+            }
+        ]
+    }
+}

--- a/examples/testsuite-contract-tests/portman-config.crm.yml
+++ b/examples/testsuite-contract-tests/portman-config.crm.yml
@@ -1,0 +1,34 @@
+version: 1
+tests:
+  contractTests:
+  # Specify the endpoint to apply the tests to: *::/crm/*
+  # The first * means match any request type, ie: GET, POST, etc..
+  # The second * means match any endpoint in the /crm/ path
+  - openApiOperation: "*::/crm/*"
+    # Check that the API returned a 2XX response
+    statusSuccess:
+      enabled: true
+    # Exclude the next test from the POST /leads and GET /crm/leads/{id} endpoint
+    excludeForOperations:
+    - leadsAdd
+    - GET::/crm/leads/{id}
+    # For all other endpoints check if response time is 300msec or less
+    responseTime:
+      enabled: true
+      maxMs: 300
+    # Check if the response contains a Content-Type header with application/json
+    contentType:
+      enabled: true
+    # Check if the response contaisn a JSON response body
+    jsonBody:
+      enabled: true
+    # Check if the response body attributes match the schema defined in the spec
+    schemaValidation:
+      enabled: true
+    # Check if the response body has any other headers that are defined in the spec
+    headersPresent:
+      enabled: true
+globals:
+  # For every request generated omit the Postman examples
+  # This helps keep the generated test collection leaner
+  stripResponseExamples: true

--- a/examples/testsuite-contract-tests/readme.md
+++ b/examples/testsuite-contract-tests/readme.md
@@ -1,22 +1,39 @@
-# OpenAPI Postman test suite generation
+# OpenAPI Postman test suite generation - Contract Tests
 
-This example contains the setup of Portman contract test generation, which will convert the OpenAPI document to a Postman collection, while adding Postman tests. The generated tests are focussed on the API contracts (the definition of the request/response with all properties), hence the reference to "API contract testing".
+Contract Tests validate that API responses match what was defined in the OpenAPI specification, ie: what was in *the contract*. 
+
+You can think of Contract Tests as "happy path" tests.  Portman generates a single request per API endpoint using the request headers, parameters and/or request bodies defined as necessary by the OpenAPI spec, so that the API should generate a 200 response.  Portman is good at automatically generating a set of tests that validate that the response matches what was defined in the spec and does it with a minimum of configuration.   
+
+Contract Tests don't do the following:
+  - validate that the values in an API response match what was expected - consider [content tests](../testsuite-content-tests/readme.md) for that
+  - test scenarios that evolve over multiple API calls, for example creating an object with a POST request, modifying it with a PUT request, validating that exists with a GET request and then deleting it with a DELETE request. - consider learning how to leverage dynamic Postman environment variables using the [assignVariables](../testsuite-assign-variables/readme.md) and [assignOverwrite](../testsuite-assign-overwrite/readme.md) portman directives for that.
+  - validate that your API correctly responds to invalid, but predictable input - consider [variation tests](../testsuite-variation-tests/readme.md) for that
+  - validate that your API is robust to unexpected input - consider [fuzz testing](../testsuite-fuzzing-tests/readme.md) for that
+  
+
+This example contains the setup of Portman contract test generation, which will convert an OpenAPI document that defines a CRM API to a Postman collection, which will include a set of tests for each Method/Endpoint. The generated tests are focused on the API contracts (the definition of the request/response with all properties), hence the reference to "API contract testing".
 
 _use-case_: convert OpenAPI to Postman with a range of Portman contract tests, automatically generated, without any complex configuration or manually written tests.
 
-## CLI usage
+## Try this example yourself using the portman CLI
+You can run this example yourself by downloading the following two files:
+- [Download Sample CRM API Spec](./crm.openapi.yml)
+- [Download Sample Contract Test Config](./portman-config.crm.yml)
+
+This example assumes you are running portman from the same directory that you download these file to, and have [installed portman locally](../../README.md#local-installation-recommended) and are running the command from the top level directory in your project. If you [installed portman globally](../../README.md#global-installation) remove the `npx` from the beginning of the command.  
+
+The example command ignores any existing portman configuration you may have setup, but if you are familiar with portman configuration you can include other parameters, for example those to automatically push the collection to Postman.
 
 ```ssh
-portman --cliOptionsFile ./examples/testsuite-contract-tests/portman-cli-options.json
+npx portman -l ./crm.openapi.yml  -c ./portman-config.crm.yml
 ```
+Since this example has no other configuration, portman will generate ./tmp/converted/crmApiContractTests.json.   You can import this into postman to view the request and the tests described in this readme.
 
-Configured by using the portman-cli config.
+This is an example where we take the OpenAPI defined in `crm.openapi.yml`, with only 1 entity (leads) to keep the example simple and convert to Postman with all the default contract tests generated out-of-the-box.
 
-This is an example where we take the OpenAPI defined in `crm.yml`, with only 1 entity (leads) to keep the example simple and convert to Postman with all the default contract tests generated out-of-the-box.
+## Portman configuration settings
 
-## Portman settings
-
-The portman settings (in JSON format) consists out of multiple parts:
+The portman settings example consists out of multiple parts:
 
 - **version** : which refers the Portman configuration version
 - **tests** : which refers the definitions for the generated contract & variance tests.
@@ -25,55 +42,45 @@ The portman settings (in JSON format) consists out of multiple parts:
     - **variationTests** : refers to the options to define variation tests.
     - **extendTests**:  which refers the custom additions of manual created Postman tests.
 
-In this example we focus on the **contractTests** section and settings.
+In this example we focus on the **contractTests** section and settings.  We use a YAML based configuration file which is a bit more compact and supports inline comments but for those who prefer json, you can find [the same configuration in json format](./portman-config.crm.json)
 
-file: examples/testsuite-contract-tests/portman-config.crm.json
+file: examples/testsuite-contract-tests/portman-config.crm.yml
 
-```json
-{
-  "version": 1.0,
-  "tests": {
-    "contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-        "statusSuccess": {
-          "enabled": true
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "responseTime": {
-          "enabled": true,
-          "maxMs": 300
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "contentType": {
-          "enabled": true
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "jsonBody": {
-          "enabled": true
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "schemaValidation": {
-          "enabled": true
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "headersPresent": {
-          "enabled": true
-        }
-      }
-    ]
-  }
-}
+```yml
+version: 1
+tests:
+  contractTests:
+  # Specify the endpoint to apply the tests to: *::/crm/*
+  # The first * means match any request type, ie: GET, POST, etc..
+  # The second * means match any endpoint in the /crm/ path
+  - openApiOperation: "*::/crm/*"
+    # Check that the API returned a 200 response
+    statusSuccess:
+      enabled: true
+    # Exclude the next test from the POST /leads and GET /crm/leads/{id} endpoint
+    excludeForOperations:
+    - leadsAdd
+    - GET::/crm/leads/{id}
+    # For all other endpoints check if response time is 300msec or less
+    responseTime:
+      enabled: true
+      maxMs: 300
+    # Check if the response contains a Content-Type header with application/json
+    contentType:
+      enabled: true
+    # Check if the response contaisn a JSON response body
+    jsonBody:
+      enabled: true
+    # Check if the response body attributes match the schema defined in the spec
+    schemaValidation:
+      enabled: true
+    # Check if the response body has any other headers that are defined in the spec
+    headersPresent:
+      enabled: true
+globals:
+  # For every request generated omit the Postman examples
+  # This helps keep the generated test collection leaner
+  stripResponseExamples: true
 ```
 
 ## Portman - "contractTests" properties
@@ -94,278 +101,64 @@ The following contract tests can be enabled by using the following properties:
 
 ## Example explained
 
-We instruct Portman to generate tests, for which the 'tests' section as defined in the **portmanConfigFile** json file, will be used.
+We instruct Portman to generate tests, via the `tests` section as defined in the **portmanConfigFile** file (specified via the `--portmanConfig` or `-c` command line option).
 
-file: examples/testsuite-contract-tests/portman-config.crm.json >>
+In our example configuration, we instructed postman to generate the following tests:
+- **statusSuccess** - check for a 2xx response code
+- **responseTime** - check for response in 300ms or less
+- **contentType** - response contains header "Content-Type: application/json"
+- **jsonBody** - response contains a json body
+- **schemaValidation** - response body attributes match spec definition
+- **headersPresent** - response contains any headers defined in spec
 
-```json
-  "tests": {
-    "contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-        "statusSuccess": {
-          "enabled": true
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "responseTime": {
-          "enabled": true,
-          "maxMs": 300
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "contentType": {
-          "enabled": true
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "jsonBody": {
-          "enabled": true
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "schemaValidation": {
-          "enabled": true
-        }
-      },
-      {
-        "openApiOperation": "*::/crm/*",
-        "headersPresent": {
-          "enabled": true
-        }
-      }
-    ]
-```
+The result will be that portman will use the OpenAPI file (specified via the `--local` or `-l` command line option), with all request and response details, to generate a postman collection with one request for each method/endpoint combination, that will include the specified tests. When the collection is loaded into Postman you can find the specific tests in the "Tests" or "Scripts" tab for each request.
 
-The result will be that initial OpenAPI file, with all request and response details will be used to generate the specific tests. Per Postman request, you can find the specific tests in the "Tests" tab in the Postman application.
+For example, after importing the generated collection (in ./tmp/converted/crmApiContractTests.json by default), open the collection "CRM API - Contract Tests" and navigate the folders "Contract Tests" >> "Leads"" >> Get lead" (3rd request in folder).  
 
-file: examples/testsuite-contract-tests/crm.postman.json >>
-
-Postman request "Leads"" >> Get lead"
+On the "Tests" or "Script tab you should see:
 
 ```js
-// Validate status 2xx
-pm.test('[GET]::/crm/leads/:id - Status code is 2xx', function () {
-  pm.response.to.be.success
-})
-
-// Validate response time
-pm.test('[GET]::/crm/leads/:id - Response time is less than 300ms', function () {
-  pm.expect(pm.response.responseTime).to.be.below(300)
-})
+// Validate status 2xx 
+pm.test("[GET]::/crm/leads/:id - Status code is 2xx", function () {
+   pm.response.to.be.success;
+});
 
 // Validate if response header has matching content-type
-pm.test('[GET]::/crm/leads/:id - Content-Type is application/json', function () {
-  pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json')
-})
+pm.test("[GET]::/crm/leads/:id - Content-Type is application/json", function () {
+   pm.expect(pm.response.headers.get("Content-Type")).to.include("application/json");
+});
 
-// Validate if response has JSON Body
-pm.test('[GET]::/crm/leads/:id - Response has JSON Body', function () {
-  pm.response.to.have.jsonBody()
-})
+// Validate if response has JSON Body 
+pm.test("[GET]::/crm/leads/:id - Response has JSON Body", function () {
+    pm.response.to.have.jsonBody();
+});
 
 // Response Validation
-const schema = {
-  type: 'object',
-  required: ['status_code', 'status', 'service', 'resource', 'operation', 'data'],
-  properties: {
-    status_code: { type: 'integer', description: 'HTTP Response Status Code', example: 200 },
-    status: { type: 'string', description: 'HTTP Response Status', example: 'OK' },
-    service: { type: 'string', description: 'Apideck ID of service provider', example: 'zoho-crm' },
-    resource: { type: 'string', description: 'Unified API resource name', example: 'companies' },
-    operation: { type: 'string', description: 'Operation performed', example: 'one' },
-    data: {
-      required: ['name', 'company_name'],
-      'x-pii': ['name', 'email', 'first_name', 'last_name'],
-      properties: {
-        id: { type: 'string', example: '12345', readOnly: true },
-        owner_id: { type: 'string', example: '54321' },
-        company_id: { type: ['string', 'null'], example: '2' },
-        company_name: { type: ['string', 'null'], example: 'Spacex' },
-        contact_id: { type: ['string', 'null'], example: '2' },
-        name: { type: 'string', example: 'Elon Musk' },
-        first_name: { type: ['string', 'null'], example: 'Elon' },
-        last_name: { type: ['string', 'null'], example: 'Musk' },
-        description: { type: ['string', 'null'], example: 'A thinker' },
-        prefix: { type: ['string', 'null'], example: 'Sir' },
-        title: { type: ['string', 'null'], example: 'CEO' },
-        status: { type: ['string', 'null'], example: 'New' },
-        monetary_amount: { type: ['number', 'null'], example: 75000 },
-        currency: { type: ['string', 'null'], example: 'USD' },
-        fax: { type: ['string', 'null'], example: '+12129876543' },
-        websites: {
-          type: 'array',
-          items: {
-            type: 'object',
-            required: ['url'],
-            properties: {
-              id: { type: ['string', 'null'], example: '12345' },
-              url: { type: 'string', example: 'http://example.com' },
-              type: {
-                type: 'string',
-                'x-graphql-type-name': 'WebsiteType',
-                enum: ['primary', 'secondary', 'work', 'personal', 'other'],
-                example: 'primary'
-              }
-            }
-          }
-        },
-        addresses: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              id: { type: ['string', 'null'], example: '123' },
-              type: {
-                type: 'string',
-                'x-graphql-type-name': 'AddressType',
-                enum: ['primary', 'secondary', 'home', 'office', 'shipping', 'billing', 'other'],
-                example: 'primary'
-              },
-              name: { type: ['string', 'null'], example: 'HQ US' },
-              line1: {
-                type: ['string', 'null'],
-                example: 'Main street',
-                description: 'Line 1 of the address e.g. number, street, suite, apt #, etc.'
-              },
-              line2: {
-                type: ['string', 'null'],
-                example: 'apt #',
-                description: 'Line 2 of the address'
-              },
-              city: {
-                type: ['string', 'null'],
-                example: 'San Francisco',
-                description: 'Name of city.'
-              },
-              state: { type: ['string', 'null'], example: 'CA', description: 'Name of state' },
-              postal_code: {
-                type: ['string', 'null'],
-                example: '94104',
-                description: 'Zip code or equivalent.'
-              },
-              country: {
-                type: ['string', 'null'],
-                example: 'US',
-                description: 'country code according to ISO 3166-1 alpha-2.'
-              },
-              latitude: { type: ['string', 'null'], example: '40.759211' },
-              longitude: { type: ['string', 'null'], example: '-73.984638' }
-            }
-          }
-        },
-        social_links: {
-          type: 'array',
-          items: {
-            required: ['url'],
-            type: 'object',
-            properties: {
-              id: { type: ['string', 'null'], example: '12345' },
-              url: { type: 'string', example: 'https://www.twitter.com/apideck-io' },
-              type: { type: ['string', 'null'], example: 'twitter' }
-            }
-          }
-        },
-        phone_numbers: {
-          type: 'array',
-          items: {
-            required: ['number'],
-            type: 'object',
-            properties: {
-              id: { type: ['string', 'null'], example: '12345' },
-              number: { type: 'string', example: '111-111-1111' },
-              type: {
-                type: 'string',
-                'x-graphql-type-name': 'PhoneType',
-                enum: [
-                  'primary',
-                  'secondary',
-                  'home',
-                  'office',
-                  'mobile',
-                  'assistant',
-                  'fax',
-                  'other'
-                ],
-                example: 'primary'
-              }
-            }
-          }
-        },
-        emails: {
-          type: 'array',
-          items: {
-            required: ['email'],
-            type: 'object',
-            properties: {
-              id: { type: 'string', example: '123' },
-              email: { type: 'string', format: 'email', example: 'elon@musk.com' },
-              type: {
-                type: 'string',
-                'x-graphql-type-name': 'EmailType',
-                enum: ['primary', 'secondary', 'work', 'personal', 'billing', 'other'],
-                example: 'primary'
-              }
-            }
-          }
-        },
-        custom_fields: {
-          type: 'array',
-          items: {
-            type: 'object',
-            required: ['id'],
-            additionalProperties: false,
-            properties: {
-              id: { type: 'string', example: 'custom_technologies' },
-              value: {
-                anyOf: [
-                  { type: ['string', 'null'], example: 'Uses Salesforce and Marketo' },
-                  { type: ['number', 'null'], example: 10 },
-                  { type: ['boolean', 'null'], example: true },
-                  { type: 'array', items: { type: 'string' } }
-                ]
-              }
-            }
-          }
-        },
-        tags: { type: 'array', items: { type: 'string' }, example: ['New'] },
-        updated_at: { type: 'string', example: '2020-09-30T07:43:32.000Z', readOnly: true },
-        created_at: { type: 'string', example: '2020-09-30T07:43:32.000Z', readOnly: true }
-      },
-      type: 'object'
-    }
-  }
-}
+const schema = {"type":"object","required":["status_code","status","service","resource","operation","data"],"properties":{"status_code":{"type":"integer","description":"HTTP Response Status Code","example":200},"status":{"type":"string","description":"HTTP Response Status","example":"OK"},"service":{"type":"string","description":"Apideck ID of service provider","example":"zoho-crm"},"resource":{"type":"string","description":"Unified API resource name","example":"companies"},"operation":{"type":"string","description":"Operation performed","example":"one"},"data":{"required":["name","company_name"],"x-pii":["name","email","first_name","last_name"],"properties":{"id":{"type":"string","example":"12345","readOnly":true},"owner_id":{"type":"string","example":"54321"},"company_id":{"type":["string","null"],"example":"2"},"company_name":{"type":["string","null"],"example":"Spacex"},"contact_id":{"type":["string","null"],"example":"2"},"name":{"type":"string","example":"Elon Musk"},"first_name":{"type":["string","null"],"example":"Elon"},"last_name":{"type":["string","null"],"example":"Musk"},"description":{"type":["string","null"],"example":"A thinker"},"prefix":{"type":["string","null"],"example":"Sir"},"title":{"type":["string","null"],"example":"CEO"},"status":{"type":["string","null"],"example":"New"},"monetary_amount":{"type":["number","null"],"example":75000},"currency":{"type":["string","null"],"example":"USD"},"fax":{"type":["string","null"],"example":"+12129876543"},"websites":{"type":"array","items":{"type":"object","required":["url"],"properties":{"id":{"type":["string","null"],"example":"12345"},"url":{"type":"string","example":"http://example.com"},"type":{"type":"string","x-graphql-type-name":"WebsiteType","enum":["primary","secondary","work","personal","other"],"example":"primary"}}}},"addresses":{"type":"array","items":{"type":"object","properties":{"id":{"type":["string","null"],"example":"123"},"type":{"type":"string","x-graphql-type-name":"AddressType","enum":["primary","secondary","home","office","shipping","billing","other"],"example":"primary"},"name":{"type":["string","null"],"example":"HQ US"},"line1":{"type":["string","null"],"example":"Main street","description":"Line 1 of the address e.g. number, street, suite, apt #, etc."},"line2":{"type":["string","null"],"example":"apt #","description":"Line 2 of the address"},"city":{"type":["string","null"],"example":"San Francisco","description":"Name of city."},"state":{"type":["string","null"],"example":"CA","description":"Name of state"},"postal_code":{"type":["string","null"],"example":"94104","description":"Zip code or equivalent."},"country":{"type":["string","null"],"example":"US","description":"country code according to ISO 3166-1 alpha-2."},"latitude":{"type":["string","null"],"example":"40.759211"},"longitude":{"type":["string","null"],"example":"-73.984638"}}}},"social_links":{"type":"array","items":{"required":["url"],"type":"object","properties":{"id":{"type":["string","null"],"example":"12345"},"url":{"type":"string","example":"https://www.twitter.com/apideck-io"},"type":{"type":["string","null"],"example":"twitter"}}}},"phone_numbers":{"type":"array","items":{"required":["number"],"type":"object","properties":{"id":{"type":["string","null"],"example":"12345"},"number":{"type":"string","example":"111-111-1111"},"type":{"type":"string","x-graphql-type-name":"PhoneType","enum":["primary","secondary","home","office","mobile","assistant","fax","other"],"example":"primary"}}}},"emails":{"type":"array","items":{"required":["email"],"type":"object","properties":{"id":{"type":"string","example":"123"},"email":{"type":"string","format":"email","example":"elon@musk.com"},"type":{"type":"string","x-graphql-type-name":"EmailType","enum":["primary","secondary","work","personal","billing","other"],"example":"primary"}}}},"custom_fields":{"type":"array","items":{"type":"object","required":["id"],"additionalProperties":false,"properties":{"id":{"type":"string","example":"custom_technologies"},"value":{"anyOf":[{"type":["string","null"],"example":"Uses Salesforce and Marketo"},{"type":["number","null"],"example":10},{"type":["boolean","null"],"example":true},{"type":"array","items":{"type":"string"}}]}}}},"tags":{"type":"array","items":{"type":"string"},"example":["New"]},"updated_at":{"type":"string","example":"2020-09-30T07:43:32.000Z","readOnly":true},"created_at":{"type":"string","example":"2020-09-30T07:43:32.000Z","readOnly":true}},"type":"object"}}}
 
-// Validate if response matches JSON schema
-pm.test('[GET]::/crm/leads/:id - Schema is valid', function () {
-  pm.response.to.have.jsonSchema(schema, { unknownFormats: ['int32', 'int64'] })
-})
+// Validate if response matches JSON schema 
+pm.test("[GET]::/crm/leads/:id - Schema is valid", function() {
+    pm.response.to.have.jsonSchema(schema,{unknownFormats: ["int32", "int64", "float", "double"]});
+});
 
-// Validate if response header is present
-pm.test('[GET]::/crm/leads/:id - Response header Operation-Location is present', function () {
-  pm.response.to.have.header('Operation-Location')
-})
+// Validate if response header is present 
+pm.test("[GET]::/crm/leads/:id - Response header Content-type is present", function () {
+   pm.response.to.have.header("Content-type");
+});
 ```
+
+Let's review the configuration and resulting tests by section:
 
 ### statusSuccess
-
-```json
-"contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-        "statusSuccess": {
-          "enabled": true
-        }
-      }
-]
+In our configuration we had the following:
+```yaml
+  - openApiOperation: "*::/crm/*"
+    # Check that the API returned a 2XX response
+    statusSuccess:
+      enabled: true
 ```
 
-Generates a check to verify if the HTTP status code is within the 2xx range
+Which instructed portman to generate a check to verify if the HTTP status code is within the 2xx range
 
 ```js
 // Validate status 2xx
@@ -374,44 +167,17 @@ pm.test('[GET]::/crm/leads/:id - Status code is 2xx', function () {
 })
 ```
 
-### statusCode
-
-```json
-"contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-      "statusCode": {
-        "enabled": true,
-        "code": 400
-        }
-      }
-]
-```
-
-Generates a check to verify if the HTTP status code matches the `code`
-
-```js
-// Validate response status code 
-pm.test('[GET]::/crm/leads/:id - Response status code time is 400', function () {
-  pm.expect(pm.response.code).to.equal(400);
-})
-```
+Note that the remaining test definitions in the configuration are all under the `OpenApiOperation: "*::/crm/*"` directive and therefore apply to the GET /crm/leads/{id} endpoint which we are examining.
 
 ### responseTime
 
-```json
-"contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-        "responseTime": {
-          "enabled": true,
-          "maxMs": 300
-        }
-      }
-]
+```yaml
+    responseTime:
+      enabled: true
+      maxMs: 300
 ```
 
-Generates a check to measure the response time, to be a maximum ms (which is set to 300ms in our example).
+Generates a check to measure the response time, to be a maximum ms (which is set to 300ms in our example).  Here is an example of a test that could be generated:
 
 ```js
 // Validate response time
@@ -420,17 +186,25 @@ pm.test('[GET]::/crm/leads/:id - Response time is less than 300ms', function () 
 })
 ```
 
+Note however that we also had this directive in our configuration:
+
+```yaml
+    excludeForOperations:
+    - leadsAdd
+    - GET::/crm/leads/{id}
+    responseTime:
+      enabled: true
+      maxMs: 300
+```
+Which specifically instructed portman NOT to generate the response time test for the GET request to the `/crm/leads/{id}` endpoint, so it is not in the complete set of tests listed above.  You can however find an example of this test in the other requests in the collection.
+
+The `excludeForOperation` directive can be applied before any test configuration.
+
 ### contentType
 
-```json
-"contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-        "contentType": {
-          "enabled": true
-        }
-      }
-]
+```yaml
+    contentType:
+      enabled: true
 ```
 
 Generates a check to validate the content-type headers, based on the content-type defined in the OpenAPI response.
@@ -444,15 +218,9 @@ pm.test('[GET]::/crm/leads/:id - Content-Type is application/json', function () 
 
 ### jsonBody
 
-```json
-"contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-        "jsonBody": {
-          "enabled": true
-        }
-      }
-]
+```yaml
+    jsonBody:
+      enabled: true
 ```
 
 Generates a check to validate if the response body is a JSON object, based on the content-type defined in the OpenAPI response.
@@ -466,15 +234,9 @@ pm.test('[GET] /crm/leads/{id} - Response has JSON Body', function () {
 
 ### headersPresent
 
-```json
-"contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-        "headersPresent": {
-          "enabled": true
-        }
-      }
-]
+```yaml
+    headersPresent:
+      enabled: true
 ```
 
 Generates a check to validate if the response has a certain HTTP header present, based on the header properties defined in the OpenAPI response.
@@ -488,18 +250,16 @@ pm.test('[GET]::/crm/leads/:id - Response header Operation-Location is present',
 
 ### schemaValidation
 
-```json
-"contractTests": [
-      {
-        "openApiOperation": "*::/crm/*",
-        "schemaValidation": {
-          "enabled": true
-        }
-      }
-]
+```yaml
+    schemaValidation:
+      enabled: true
 ```
 
-Generates a check to validate if the response respects all the defined response properties, allowed property types, required fields, allowed enums, .... It does a full JSON schema verification, based on the OpenAPI response properties.
+Generates a check to validate if the response respects all the defined response properties, allowed property types, required fields, allowed enums, .... 
+
+Portman builds a full JSON schema object based on the response defintion in the OpenAPI spec and validates that the response matches it. 
+
+This particular test is one of the most useful, and will often catch issues with the API implementation that might have otherwise been missed without the ability to quickly generate an automated test to validate that the response meets the contract.
 
 ```js
 // Response Validation
@@ -678,6 +438,33 @@ const schema = {
 // Validate if response matches JSON schema
 pm.test('[GET]::/crm/leads/:id - Schema is valid', function () {
   pm.response.to.have.jsonSchema(schema, { unknownFormats: ['int32', 'int64'] })
+})
+```
+
+## Examples of generated tests that are not in our sample config
+
+The following tests were not included in our example configuration but are still useful in certain situations.   We provide these example configuration in JSON format to demonstrate both YAML and JSON configuration approaches:
+
+### statusCode
+The configuration:
+```json
+"contractTests": [
+      {
+        "openApiOperation": "*::/crm/*",
+        "statusCode": {
+          "enabled": true,
+          "code": 400
+        }
+      }
+]
+```
+
+Generates a check to verify if the HTTP status code matches the `code`
+
+```js
+// Validate response status code 
+pm.test('[GET]::/crm/leads/:id - Response status code time is 400', function () {
+  pm.expect(pm.response.code).to.equal(400);
 })
 ```
 


### PR DESCRIPTION
As a new Portman user I struggled a bit getting up to speed.  There is SO much info in the readme.   After the getting started, the initial readme jumps into things like portman CLI configuration and Postman/Newman variables, but as a new user I was more interested in learning about what types of tests the tool could make and how to set them up.   It actually took me several days of playing with it, reading the main readme from top to bottom, and accidentally discovering that I was getting contract tests despite being misconfigured, before I began to realize how to process the documentation.

TL:DR - the "good stuff" is really in the examples!

With that in mind here are some suggested changes that might make it easier for other first time users.   I won't be upset if you don't choose to take this PR, or only want parts of it, but this tool is so cool and helpful, I wanted to give back in some way.

Main README 
- In the initial section that describes all the things you can do with Portman, I added "learn more" links that take you right to the relevant example.   (Note -- the items that don't have this link are still puzzling to me!)
-  In the Getting Started section I added  another "OR" that suggests just trying to run Portman without any configuration to get a sense of what it can do.   The first time you see that Postman collection with contract tests is a game changer!   This approach lets a new user get to it very quickly without needing to learn all the configuration options
  - When I discovered that Portman makes contract tests without any configuration at all I thought it was really cool.  I attempted to create a configuration that matches the default configuration and I reference it in my 3rd alternate "Getting Started" option. 

Contract Test examples readme:
- I did a fairly significant update of the readme for the Contract Tests because I think its a great place to start
  - Give a little more description about what a contract test is
  - Update the try it out section so that a user who installs portman can run the samples directly without any other configuration
  - Use a yaml based example since its easier to read and supports inline comments
  -  Specify the operationId just once for all the contract tests in the config instead of once per test
  
I hope this is accepted in the spirit it is offered!
 