### PR TITLE
Template expression: Fix to handle double/triple curly braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Template expression: Fix to handle double/triple curly braces (#597)
 - overwriteRequestHeaders - Allow zero value
 - overwriteRequestPathVariables - Allow zero value
 - overwriteRequestQueryParams - Allow zero value (#603)

--- a/src/utils/parseTpl.test.ts
+++ b/src/utils/parseTpl.test.ts
@@ -203,6 +203,17 @@ describe('parseTpl', () => {
     const result = parseTpl(dto)
     expect(result).toBe('{{leadsId}}_{{leadsAdd}} ')
   })
+
+  test('generates variable name with casing, keeping the {{{}}}', () => {
+    const dto = {
+      template: '{{{<tag>MonetaryAmount}}}',
+      oaOperation: oaOperationOne,
+      dynamicValues: { responseProp: 'id' },
+      options: { casing: 'camelCase' }
+    }
+    const result = parseTpl(dto)
+    expect(result).toBe('{{{leadsMonetaryAmount}}}')
+  })
 })
 
 describe('hasTpl', () => {

--- a/src/utils/parseTpl.ts
+++ b/src/utils/parseTpl.ts
@@ -93,12 +93,12 @@ export const parseTpl = (dto: GenerateVarNameDTO): string => {
 
   // Apply casing
   if (options?.casing && varName && options?.caseOnlyExpressions !== true) {
-    const placeholderRegex = new RegExp(`{{(.*?)}}`, 'g')
-    varName = varName.replace(placeholderRegex, (_, placeholder) => {
+    const placeholderRegex = new RegExp(`({{{?|{{)(.*?)(}}}?|}})`, 'g')
+    varName = varName.replace(placeholderRegex, (_, openingBraces, placeholder, closingBraces) => {
       if (options.casing) {
-        return `{{${changeCase(placeholder.trim(), options.casing)}}}`
+        return `${openingBraces}${changeCase(placeholder.trim(), options.casing)}${closingBraces}`
       }
-      return `{{${placeholder}}}`
+      return `${openingBraces}${placeholder}${closingBraces}`
     })
     if (!varName.includes('{{') && !varName.includes('}}')) {
       varName = changeCase(varName, options.casing)


### PR DESCRIPTION
linked to #597 


```yaml
overwrites:
#  - openApiOperation: "*::/crm/*/{id}"
#    excludeForOperations:
#      - POST::*
#    overwriteRequestPathVariables:
#      - key: id
#        value: "{{<tag>Id}}"
#        overwrite: true
  # When updating a lead use the Monetary Amount environment variable
  - openApiOperation: "PATCH::/crm/leads/{id}"
    overwriteRequestBody:
      - key: monetary_amount
        value: '{{{<tag>MonetaryAmount}}}'
        overwrite: true
```

Result in: 

BEFORE
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/2147cf17-9682-470f-a2ad-c5377434e439">


AFTER
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/91862a75-7e9c-4988-a2e9-ed8d60094be3">
