### PR TITLE
overwriteRequestQueryParams - Handle form encoded array query params

### DIFF
--- a/src/application/overwrites/overwriteRequestQueryParams.test.ts
+++ b/src/application/overwrites/overwriteRequestQueryParams.test.ts
@@ -540,4 +540,125 @@ describe('overwriteRequestQueryParams', () => {
     const result = overwriteRequestQueryParams(dto)
     expect(result.item.request.url.query).toMatchSnapshot()
   })
+
+  it('should correctly handle multiple duplicate query params with matching overwrite values', async () => {
+    const overwriteValues = [
+      {
+        key: 'name',
+        value: 'newName',
+        overwrite: true
+      },
+      {
+        key: 'ids',
+        value: 'newId1',
+        overwrite: true
+      },
+      {
+        key: 'first',
+        value: 'newFirst',
+        overwrite: true
+      },
+      {
+        key: 'ids',
+        value: 'newId2',
+        overwrite: true
+      },
+      {
+        key: 'ids',
+        value: 'newId3',
+        overwrite: true
+      },
+      {
+        key: 'number',
+        value: 'newNumber1',
+        overwrite: true
+      },
+      {
+        key: 'number',
+        value: 'newNumber2',
+        overwrite: true
+      },
+      {
+        key: 'word',
+        value: 'newWord',
+        overwrite: true
+      }
+    ]
+
+    // Set up initial query params
+    const pmQueryParams = [
+      {
+        key: 'name',
+        value: 'oldName',
+        disabled: false
+      },
+      {
+        key: 'ids',
+        value: 'oldId1',
+        disabled: false
+      },
+      {
+        key: 'ids',
+        value: 'oldId2',
+        disabled: false
+      },
+      {
+        key: 'ids',
+        value: 'oldId3',
+        disabled: false
+      },
+      {
+        key: 'first',
+        value: 'oldFirst',
+        disabled: false
+      },
+      {
+        key: 'last',
+        value: 'oldLast',
+        disabled: false
+      },
+      {
+        key: 'number',
+        value: 'oldNumber1',
+        disabled: false
+      },
+      {
+        key: 'word',
+        value: 'oldWord',
+        disabled: false
+      },
+      {
+        key: 'number',
+        value: 'oldNumber2',
+        disabled: false
+      }
+    ]
+
+    // Add the query params to the pmOperation
+    // pmQueryParams.forEach(param => pmOperation.item.request.url.query.upsert(new QueryParam(param)))
+    pmQueryParams.forEach(param => {
+      pmOperation.item.request.url.query.append(new QueryParam(param))
+    })
+
+    const dto = {
+      overwriteValues,
+      pmOperation,
+      oaOperation
+    }
+
+    const result = overwriteRequestQueryParams(dto)
+
+    expect(result.item.request.url.query.map(qp => ({ key: qp.key, value: qp.value }))).toEqual([
+      { key: 'raw', value: 'true' },
+      { key: 'name', value: 'newName' },
+      { key: 'ids', value: 'newId1' },
+      { key: 'ids', value: 'newId2' },
+      { key: 'ids', value: 'newId3' },
+      { key: 'first', value: 'newFirst' },
+      { key: 'last', value: 'oldLast' }, // unchanged
+      { key: 'number', value: 'newNumber1' },
+      { key: 'word', value: 'newWord' },
+      { key: 'number', value: 'newNumber2' }
+    ])
+  })
 })

--- a/src/application/overwrites/overwriteRequestQueryParams.ts
+++ b/src/application/overwrites/overwriteRequestQueryParams.ts
@@ -2,6 +2,7 @@ import { PostmanMappedOperation } from '../../postman'
 import { QueryParam } from 'postman-collection'
 import { parseTpl, hasTpl, matchWildcard } from '../../utils'
 import { OverwriteRequestDTO } from './applyOverwrites'
+import _ from 'lodash'
 
 /**
  * Overwrite Postman request query params with values defined by the portman testsuite
@@ -13,42 +14,45 @@ export const overwriteRequestQueryParams = (dto: OverwriteRequestDTO): PostmanMa
   // Early exit if overwrite values are not defined
   if (!(overwriteValues instanceof Array)) return pmOperation
 
-  // Early exit if request url query is not defined
-  // if (!pmOperation.item?.request?.url?.query) return pmOperation
-
   // Get all Postman query params
   const queryKeys = pmOperation.item.request.url.query.map(({ key }) => key)
+
   // Detect overwrite query params that do not exist in the Postman collection
   const insertNewKeys = overwriteValues.filter(x => !queryKeys.includes(x.key))
 
-  // Initialize a map to track occurrences of each query key
-  const keyPositionMap = new Map<string, number>()
+  // Extract duplicate query params
+  const duplicateKeys = _(queryKeys)
+    .countBy()
+    .pickBy((count: number) => count > 1)
+    .keys()
+    .value()
+
+  // Initialize counters for tracking
+  const queryKeyCounters = {}
+  const overwriteKeyCounters = {}
+  const duplicateKeyCounters = {}
+
+  // Util function to get the count of key
+  const getKeyCount = (key, counter) => counter[key] || 0
+
+  // Util function to increment the key count
+  const incrementKeyCount = (key, counter) => {
+    counter[key] = getKeyCount(key, counter) + 1
+    return counter[key]
+  }
 
   pmOperation.item.request.url.query.each(pmQueryParam => {
-    // Overwrite values for Keys
-    overwriteValues.forEach(overwriteItem => {
-      // Track the current position of this key
-      const keyCount = keyPositionMap.get(overwriteItem.key) || 0
-      keyPositionMap.set(overwriteItem.key, keyCount + 1)
+    // Increment counter for query param
+    const queryKeyIndex = incrementKeyCount(pmQueryParam.key, queryKeyCounters)
 
+    // Overwrite values for Keys
+    for (const overwriteItem of overwriteValues) {
       // Skip keys when no overwrite is defined
       if (
         !(overwriteItem?.key && pmQueryParam?.key && overwriteItem.key === pmQueryParam.key) &&
         !overwriteItem.key.includes('*')
       ) {
-        return
-      }
-
-      // Handle positional logic
-      if (overwriteItem.key === pmQueryParam.key) {
-        const currentKeyCount = keyPositionMap.get(overwriteItem.key)
-        const matchingOverwriteItems = overwriteValues.filter(
-          item => item.key === overwriteItem.key
-        )
-        if (currentKeyCount && currentKeyCount > matchingOverwriteItems.length) {
-          return
-        }
-        overwriteItem = matchingOverwriteItems[currentKeyCount - 1] || overwriteItem
+        continue
       }
 
       // Check wildcard match
@@ -57,8 +61,11 @@ export const overwriteRequestQueryParams = (dto: OverwriteRequestDTO): PostmanMa
         pmQueryParam.key &&
         !matchWildcard(pmQueryParam.key, overwriteItem.key)
       ) {
-        return
+        continue
       }
+
+      // Increment counter for overwrite key
+      const overwriteKeyIndex = incrementKeyCount(overwriteItem.key, overwriteKeyCounters)
 
       const generatedName = parseTpl({
         template: overwriteItem.value,
@@ -67,8 +74,27 @@ export const overwriteRequestQueryParams = (dto: OverwriteRequestDTO): PostmanMa
           casing: globals?.variableCasing
         }
       })
-      const overwriteValue =
+      let overwriteValue =
         overwriteItem?.value && hasTpl(overwriteItem.value) ? generatedName : overwriteItem?.value
+
+      // Handle duplicated query params
+      let duplicateFound = false
+      if (
+        duplicateKeys.length > 0 &&
+        duplicateKeys.includes(pmQueryParam.key) &&
+        overwriteItem.key === pmQueryParam.key &&
+        queryKeyIndex === overwriteKeyIndex
+      ) {
+        const duplicateKeyIndex = getKeyCount(overwriteItem.key, duplicateKeyCounters)
+        const matchingOverwriteItems = overwriteValues.filter(item => item.key === pmQueryParam.key)
+
+        const overwriteObj = matchingOverwriteItems[duplicateKeyIndex]
+        if (overwriteObj.value) {
+          overwriteValue = overwriteObj.value
+          incrementKeyCount(overwriteItem.key, duplicateKeyCounters)
+          duplicateFound = true
+        }
+      }
 
       // Test suite - Overwrite/extend query param value
       let hasValue = false
@@ -102,7 +128,12 @@ export const overwriteRequestQueryParams = (dto: OverwriteRequestDTO): PostmanMa
 
       // Set Postman query param
       pmOperation.item.request.url.query.upsert(pmQueryParam)
-    })
+
+      // Break the loop once a matching overwrite is applied
+      if (duplicateFound) {
+        break
+      }
+    }
   })
 
   // Test suite - Remove query param


### PR DESCRIPTION
linked to #640 

OpenAPI

```
      parameters:
     ...
        - name: ids
          in: query
          description: >
            A form serialized array of category IDs to filter the results. <br>
            IDs that do not exist are ignored.
          required: false
          schema:
            type: array
            items:
              type: integer
          style: form
          examples:
            child_ids:
              value:
                - 315162
                - 315163
                - 315164
            top_level:
              value:
                - 83
                - 84
```

Portman Config
```
"overwrites": [
    {
      "openApiOperation": "*::*",
      "overwriteRequestQueryParams": [
        {
          "key": "name",
          "value": "{{newName}}"
        },
        {
          "key": "ids",
          "value": "{{_categoryId1}}"
        },
        {
          "key": "first",
          "value": "{{newFirst}}"
        },
        {
          "key": "ids",
          "value": "{{_categoryId2}}"
        },
        {
          "key": "ids",
          "value": "{{_categoryId3}}"
        }
      ,
        {
          "key": "number",
          "value": "{{newNumber1}}"
        },
        {
          "key": "number",
          "value": "{{newNumber2}}"
        },
        {
          "key": "word",
          "value": "{{newWord}}"
        }
      ]
    }
  ],
```

BEFORE
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/95fca0c3-3eb0-4d9b-8542-f07be502430d">


AFTER
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/3ab65a45-3256-458f-83ab-8a95362cc188">
