### PR TITLE
overwrite - handle overwrite of non-empty objects with plain values

### DIFF
--- a/src/utils/setByPath.test.ts
+++ b/src/utils/setByPath.test.ts
@@ -356,4 +356,21 @@ describe('setByPath', () => {
       numbers: [98618922, -367]
     })
   })
+
+  it('should replace an existing object with a primitive value', () => {
+    const objUnderTest = {
+      event: {
+        startDateTime: {
+          format: 'date-time'
+        }
+      }
+    }
+
+    const result = setByPath(objUnderTest, 'event.startDateTime', '2002-12-01')
+    expect(result).toEqual({
+      event: {
+        startDateTime: '2002-12-01'
+      }
+    })
+  })
 })

--- a/src/utils/setByPath.ts
+++ b/src/utils/setByPath.ts
@@ -23,6 +23,13 @@ export const setByPath = (
     dot.keepArray = true
   }
 
+  // Check if the path leads to an object that should be replaced
+  const currentValue = dot.pick(path, objectOrArray)
+  if (isObject(currentValue) && !isObject(newValue)) {
+    // Directly replace the object with the new value
+    dot.del(path, objectOrArray)
+  }
+
   // Handle array of objects
   if (Array.isArray(objectOrArray)) {
     // Handle array definition (example: [0])


### PR DESCRIPTION
linked to #646 

Result before:
```
/Path/to/repro/node_modules/dot-object/index.js:118
        throw new Error("Trying to redefine non-empty obj['" + k + "']")
              ^

Error: Trying to redefine non-empty obj['startDateTime']
    at DotObject._fill (/Path/to/repro/node_modules/dot-object/index.js:118:15)
    at DotObject._fill (/Path/to/repro/node_modules/dot-object/index.js:114:10)
    at DotObject.str (/Path/to/repro/node_modules/dot-object/index.js:179:10)
```

Result after:
<img width="732" alt="image" src="https://github.com/user-attachments/assets/a6bbb819-f22d-4e85-88c4-b17ca982d2b9">
