### PR TITLE
Doc value as dot for entire result

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,9 @@ While the Portman `tests` verify the "contract" of the API, the `contentTests` w
 
 - **responseBodyTests (Array)** : Array of key/value pairs of properties & values in the Postman response body.
 
-  - **key (String)** : The key that will be targeted in the response body to check if it exists. To look up a key within in array of objects, you can use an array index (example `data.websites[0].url`) or a * wildcard (example: `data.websites[*].url`) which uses the `value` to match an object in an array. 
+  - **key (String)** : The key that will be targeted in the response body to check if it exists. 
+    - To look up a key within in array of objects, you can use an array index (example `data.websites[0].url`) or a * wildcard (example: `data.websites[*].url`) which uses the `value` to match an object in an array. 
+    - To test a response body that is a single value instead of a JSON object, set this to '.'
   - **value (String)** : The value that will be used to check if the value in the response body property matches.
   - **contains (String)** : The value that will be used to check if the value is present in the value of the response body property.
   - **oneOf (String[],Number[],Boolean[])** : The value that will be used to check one of the values is matching the response body property.

--- a/examples/testsuite-content-tests/readme.md
+++ b/examples/testsuite-content-tests/readme.md
@@ -484,7 +484,7 @@ if (jsonData?.service) {
 ```
 
 > **REMARK**:
-> If you have an API that returns a single value, such as a number or a boolean, instead of a JSON object you can set `value` to `.` to apply the test against the entire result
+> If you have an API that returns a single value, such as a number or a boolean, instead of a JSON object you can set `key` to `.` to apply the test against the entire result
 
 `non JSON object response` configuration example:
 

--- a/examples/testsuite-content-tests/readme.md
+++ b/examples/testsuite-content-tests/readme.md
@@ -483,6 +483,37 @@ if (jsonData?.service) {
   })};
 ```
 
+> **REMARK**:
+> If you have an API that returns a single value, such as a number or a boolean, instead of a JSON object you can set `value` to `.` to apply the test against the entire result
+
+`non JSON object response` configuration example:
+
+```json
+ "responseBodyTests": [
+  {
+    "key": ".",
+    "value": true
+  }
+]
+```
+
+`non JSON object response` generated test example:
+```js
+// Set property value as variable
+const _res = jsonData;
+
+// Response body should have "ROOT"
+pm.test("[GET]::/return_boolean - Content check if 'ROOT' exists", function() {
+   pm.expect(_res !== undefined).to.be.true;
+});
+
+// Response body should have value "true" for "ROOT"
+if (_res !== undefined) {
+pm.test("[GET]::/return_boolean - Content check if value for 'ROOT' matches 'true'", function() {
+  pm.expect(_res).to.eql(true);
+})};
+
+```
 ---
 
 ### responseHeaderTests


### PR DESCRIPTION
Document the ability to set key to "." in order to apply a responseBodyTest against the entire response for APIs that return single values like a number or a boolean