### PR TITLE
fix(fuzzer): only map required fields if node.required is an array

### DIFF
--- a/src/application/Fuzzer.test.ts
+++ b/src/application/Fuzzer.test.ts
@@ -2032,4 +2032,31 @@ describe('Fuzzer', () => {
     const result = fuzzer.analyzeHeaderSchema(reqHeaders[0])
     expect(result).toMatchSnapshot()
   })
+
+  it('should not break when a property is named "required" and is not an array', () => {
+    // Schema with a property named 'required' that is not an array
+    const schema = {
+      type: 'object',
+      properties: {
+        required: {
+          type: 'string',
+          example: 'not-an-array'
+        },
+        name: {
+          type: 'string'
+        }
+      },
+      required: ['name']
+    } as OpenAPIV3.SchemaObject
+
+    const fuzzer = new Fuzzer({
+      testSuite: {} as any,
+      variationWriter: {} as any
+    })
+
+    const result = fuzzer.analyzeFuzzJsonSchema(schema)
+    expect(result).not.toBeNull();
+    expect(result!.requiredFields).toContain('name')
+    expect(result!.requiredFields).not.toContain('required')
+  })
 })

--- a/src/application/Fuzzer.ts
+++ b/src/application/Fuzzer.ts
@@ -897,7 +897,7 @@ export class Fuzzer {
         }
 
         // Register fuzz-able required fields from the 'required' element on an object; exclude properties named 'required'.
-        if (key !== 'properties') {
+        if (key !== 'properties' && Array.isArray(node.required)) {
           const requiredFuzz = node.required.map(req => `${requiredPath}${req}`)
           fuzzItems.requiredFields = fuzzItems.requiredFields.concat(requiredFuzz) || []
         }


### PR DESCRIPTION
Added a type check (Array.isArray(node.required)) in the Fuzzer logic to ensure only arrays are processed as required fields.

This change prevents runtime errors and ensures the Fuzzer works correctly with OpenAPI schemas that have properties named required, which are not intended to be arrays of required fields.