### PR TITLE
move tslib to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "pluralize": "^8.0.0",
         "postman-collection": "5.0.2",
         "prompts": "^2.4.2",
+        "tslib": "^2.6.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -57,7 +58,6 @@
         "ts-json-schema-generator": "^0.95.0",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^3.15.0",
-        "tslib": "^2.6.2",
         "typescript": "^4.9.5"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "ts-json-schema-generator": "^0.95.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^3.15.0",
-    "tslib": "^2.6.2",
     "typescript": "^4.9.5"
   },
   "dependencies": {
@@ -87,6 +86,7 @@
     "pluralize": "^8.0.0",
     "postman-collection": "5.0.2",
     "prompts": "^2.4.2",
+    "tslib": "^2.6.2",
     "yargs": "^17.7.2"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- `tsconfig.json` sets `importHelpers: true`, so emitted code does `require("tslib")` at runtime (61 files in `dist/` currently).
- `tslib` was only listed in `devDependencies`, so consumers installing `@apideck/portman` would fail with `Cannot find module 'tslib'`.
- Moves `tslib` into runtime `dependencies` and updates the lockfile.

## Options considered
1. **Keep as-is (now that tslib is a dep)** — recommended, smallest change. _(chosen)_
2. **Drop `importHelpers` + leave tslib out** — simpler deps, larger `dist/` (each file inlines its own helpers).
3. **Bump `target` to `es2019`** (Node 12+ supports it, matches `engines`) — eliminates most helpers entirely, but it's a broader change that could surface other issues and is outside the scope of this fix.

## Test plan
- [x] `npm run build` succeeds
- [x] Emitted `dist/**/*.js` files resolve `tslib` from runtime deps
- [ ] Install from a tarball in a clean consumer project and require the package